### PR TITLE
Fix Build Break With USD Future 25.08 Release

### DIFF
--- a/source/geometry/geometry.cpp
+++ b/source/geometry/geometry.cpp
@@ -586,7 +586,11 @@ HdContainerDataSourceHandle Create2DMaterial(
 
     SdrRegistry& shaderReg = SdrRegistry::GetInstance();
     SdrShaderNodeConstPtr sdrSurfaceNode =
+#if PXR_VERSION >= 2505
+        shaderReg.GetShaderNodeFromSourceCode(source, HioGlslfxTokens->glslfx, SdrTokenMap());
+#else
         shaderReg.GetShaderNodeFromSourceCode(source, HioGlslfxTokens->glslfx, NdrTokenMap());
+#endif
 
     auto terminalsDs = HdRetainedContainerDataSource::New(
         HdMaterialTerminalTokens->surface, HdMaterialConnectionSchema::Builder().Build());


### PR DESCRIPTION
Use SdrTokenMap of usd 25.05 as NdrTokenMap will be removed in future 25.08 release.