### PR TITLE
Align tests with baseline names

### DIFF
--- a/test/tests/testComposeTask.cpp
+++ b/test/tests/testComposeTask.cpp
@@ -47,9 +47,9 @@ constexpr int imageHeight { 768 };
 // Refer to https://forum.aousd.org/t/hdstorm-mesh-wires-drawing-issue-in-usd-24-05-on-macos/1523
 //
 #if defined(__ANDROID__) || defined(__APPLE__)
-TEST(TestViewportToolbox, DISABLED_Compose_ComposeTask)
+TEST(TestViewportToolbox, DISABLED_compose_ComposeTask)
 #else
-TEST(TestViewportToolbox, Compose_ComposeTask)
+TEST(TestViewportToolbox, compose_ComposeTask)
 #endif
 {
     // This unit test uses the 'Storm' render delegate for the two frame passes, to demonstrate that
@@ -144,9 +144,9 @@ TEST(TestViewportToolbox, Compose_ComposeTask)
 // Refer to https://forum.aousd.org/t/hdstorm-mesh-wires-drawing-issue-in-usd-24-05-on-macos/1523
 //
 #if defined(__ANDROID__) || defined(__APPLE__)
-TEST(TestViewportToolbox, DISABLED_Compose_ShareTextures)
+TEST(TestViewportToolbox, DISABLED_compose_ShareTextures)
 #else
-TEST(TestViewportToolbox, Compose_ShareTextures)
+TEST(TestViewportToolbox, compose_ShareTextures)
 #endif
 {
     // This unit test uses the 'Storm' render delegate for the two frame passes, to demonstrate that
@@ -245,9 +245,9 @@ TEST(TestViewportToolbox, Compose_ShareTextures)
 
 // Disabled for iOS as the result is not stable. Refer to OGSMOD-7344
 #if TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_Compose_ComposeTask2)
+TEST(TestViewportToolbox, DISABLED_compose_ComposeTask2)
 #else
-TEST(TestViewportToolbox, Compose_ComposeTask2)
+TEST(TestViewportToolbox, compose_ComposeTask2)
 #endif
 {
     // This unit test uses the 'Storm' render delegate for the two frame passes, to demonstrate that
@@ -333,9 +333,9 @@ TEST(TestViewportToolbox, Compose_ComposeTask2)
 
 // Disabled for iOS as the result is not stable. Refer to OGSMOD-7344
 #if TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_Compose_ComposeTask3)
+TEST(TestViewportToolbox, DISABLED_compose_ComposeTask3)
 #else
-TEST(TestViewportToolbox, Compose_ComposeTask3)
+TEST(TestViewportToolbox, compose_ComposeTask3)
 #endif
 {
     // This unit test performs the same validation than the 'Compose_ComposeTask2' unit test but the
@@ -422,9 +422,9 @@ TEST(TestViewportToolbox, Compose_ComposeTask3)
 // NOTE: Android unit test regularly intermittently fails, not always rendering the bounding box.
 // Refer to OGSMOD-7309.
 #if defined(__ANDROID__)
-TEST(TestViewportToolbox, DISABLED_Compose_ShareTextures4)
+TEST(TestViewportToolbox, DISABLED_compose_ShareTextures4)
 #else
-TEST(TestViewportToolbox, Compose_ShareTextures4)
+TEST(TestViewportToolbox, compose_ShareTextures4)
 #endif
 {
     // This unit test performs the same validation than the 'Compose_ComposeTask3' unit test except

--- a/test/tests/testFramePass.cpp
+++ b/test/tests/testFramePass.cpp
@@ -40,7 +40,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
-TEST(TestViewportToolbox, FramePassUID)
+TEST(TestViewportToolbox, framePassUID)
 {
     // The unit tests the name & unique identifier using the various ways to create a frame pass
     // instance.
@@ -100,9 +100,9 @@ TEST(TestViewportToolbox, FramePassUID)
 // issues. Refer to OGSMOD-5546.
 //
 #if defined(__ANDROID__) || defined(__APPLE__) || defined(__linux__)
-TEST(TestViewportToolbox, DISABLED_TestFramePassColorSpace)
+TEST(TestViewportToolbox, DISABLED_testFramePassColorSpace)
 #else
-TEST(TestViewportToolbox, TestFramePassColorSpace)
+TEST(TestViewportToolbox, testFramePassColorSpace)
 #endif
 {
     // The goal of the unit test is to validate the colorspace value in FramePassParams is properly
@@ -233,9 +233,9 @@ void TestDynamicFramePassParams(
 }
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestDynamicCameraAndLights)
+TEST(TestViewportToolbox, DISABLED_testDynamicCameraAndLights)
 #else
-TEST(TestViewportToolbox, TestDynamicCameraAndLights)
+TEST(TestViewportToolbox, testDynamicCameraAndLights)
 #endif
 {
     // Use a fixed resolution (the image width/height do not change).
@@ -282,9 +282,9 @@ TEST(TestViewportToolbox, TestDynamicCameraAndLights)
 }
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestDynamicResolution)
+TEST(TestViewportToolbox, DISABLED_testDynamicResolution)
 #else
-TEST(TestViewportToolbox, TestDynamicResolution)
+TEST(TestViewportToolbox, testDynamicResolution)
 #endif
 {
     // Render at half resolution for the first few frames, then change the render size to the full


### PR DESCRIPTION
Baseline images are lowerCamelCase. Updating tests to be consistent.