### PR TITLE
Android, iOS baseline images, test path updates

### DIFF
--- a/test/RenderingFramework/AndroidTestContext.cpp
+++ b/test/RenderingFramework/AndroidTestContext.cpp
@@ -308,7 +308,7 @@ AndroidTestContext::AndroidTestContext(int w, int h) : TestContext(w, h)
 
 void AndroidTestContext::init()
 {
-    std::string localAppPath = getenv("APP_SOURCE_PATH");
+    std::string localAppPath = getenv("APP_HVT_TEST_ASSETS");
     _sceneFilepath           = localAppPath + "/usd/test_fixed.usda";
 
     // Create the renderer context required for Hydra.

--- a/test/RenderingFramework/CMakeLists.txt
+++ b/test/RenderingFramework/CMakeLists.txt
@@ -66,7 +66,7 @@ target_compile_definitions(${_TARGET}
 # Where to find all the data files for the unit tests.
 target_compile_definitions(${_TARGET}
     PRIVATE
-        TEST_DATA_RESOURCE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/..
+        TEST_HVT_DATA_PATH=${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
 # Where to output any processing results.

--- a/test/RenderingFramework/MetalTestContext.mm
+++ b/test/RenderingFramework/MetalTestContext.mm
@@ -383,7 +383,7 @@ MetalTestContext::MetalTestContext(int w, int h) : TestContext(w, h)
 
 void MetalTestContext::init()
 {
-    _sceneFilepath = mainBundlePath() + "/data/data/assets/usd/test_fixed.usda";
+    _sceneFilepath = mainBundlePath() + "/data/assets/usd/test_fixed.usda";
 
     // Create the renderer context required for Hydra.
     _backend = std::make_shared<TestHelpers::MetalRendererContext>(_width, _height);
@@ -392,7 +392,7 @@ void MetalTestContext::init()
         throw std::runtime_error("Failed to initialize the unit test backend!");
     }
     
-    _backend->setDataPath(mainBundlePath() + "/data/data/");
+    _backend->setDataPath(mainBundlePath() + "/data/");
 }
 
 } // namespace TestHelpers

--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -317,7 +317,7 @@ void OpenGLTestContext::init()
 {
     namespace fs = std::filesystem;
 
-    _sceneFilepath = TOSTRING(TEST_DATA_RESOURCE_PATH) + "/data/assets/usd/test_fixed.usda";
+    _sceneFilepath = TOSTRING(TEST_HVT_DATA_PATH) + "/data/assets/usd/test_fixed.usda";
 
     // Create the renderer context required for Hydra.
     _backend = std::make_shared<TestHelpers::OpenGLRendererContext>(_width, _height);
@@ -327,7 +327,7 @@ void OpenGLTestContext::init()
     }
 
     fs::path dataPath =
-        std::filesystem::path(TOSTRING(TEST_DATA_RESOURCE_PATH), fs::path::native_format);
+        std::filesystem::path(TOSTRING(TEST_HVT_DATA_PATH), fs::path::native_format);
     dataPath.append("data/assets");
     _backend->setDataPath(dataPath);
 }

--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -58,14 +58,14 @@ const std::string resFullpath            = TestHelpers::mainBundlePath() + "/dat
 std::filesystem::path inBaselinePath     = TestHelpers::mainBundlePath() + "/data/baselines";
 #elif __ANDROID__
 const std::filesystem::path outFullpath  = getenv("APP_CACHE_PATH");
-const std::filesystem::path inAssetsPath = getenv("APP_SOURCE_PATH");
-const std::string resFullpath            = getenv("APP_DATA_PATH");
-std::filesystem::path inBaselinePath     = getenv("APP_BASELINES_PATH");
+const std::filesystem::path inAssetsPath = getenv("APP_HVT_TEST_ASSETS");
+const std::string resFullpath            = getenv("APP_HVT_RESOURCES");
+std::filesystem::path inBaselinePath     = getenv("APP_HVT_BASELINES");
 #else
 const std::filesystem::path outFullpath  = TOSTRING(TEST_DATA_OUTPUT_PATH) + "/computed";
-const std::filesystem::path inAssetsPath = TOSTRING(TEST_DATA_RESOURCE_PATH) + "/data/assets";
+const std::filesystem::path inAssetsPath = TOSTRING(TEST_HVT_DATA_PATH) + "/data/assets";
 const std::string resFullpath            = TOSTRING(HVT_RESOURCE_PATH);
-std::filesystem::path inBaselinePath     = TOSTRING(TEST_DATA_RESOURCE_PATH) + "/data/baselines";
+std::filesystem::path inBaselinePath     = TOSTRING(TEST_HVT_DATA_PATH) + "/data/baselines";
 #endif
 
 } // anonymous namespace

--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -53,7 +53,7 @@ namespace
 
 #if TARGET_OS_IPHONE
 const std::filesystem::path outFullpath  = TestHelpers::documentDirectoryPath() + "/Data";
-const std::filesystem::path inAssetsPath = TestHelpers::mainBundlePath() + "/data/data/assets";
+const std::filesystem::path inAssetsPath = TestHelpers::mainBundlePath() + "/data/assets";
 const std::string resFullpath            = TestHelpers::mainBundlePath() + "/data";
 std::filesystem::path inBaselinePath     = TestHelpers::mainBundlePath() + "/data/baselines";
 #elif __ANDROID__

--- a/test/RenderingFramework/VulkanTestContext.cpp
+++ b/test/RenderingFramework/VulkanTestContext.cpp
@@ -885,7 +885,7 @@ void VulkanTestContext::init()
 {
     namespace fs = std::filesystem;
 
-    _sceneFilepath = TOSTRING(TEST_DATA_RESOURCE_PATH) + "/data/assets/usd/test_fixed.usda";
+    _sceneFilepath = TOSTRING(TEST_HVT_DATA_PATH) + "/data/assets/usd/test_fixed.usda";
 
     // Create the renderer context required for Hydra.
     _backend = std::make_shared<TestHelpers::VulkanRendererContext>(_width, _height);
@@ -895,7 +895,7 @@ void VulkanTestContext::init()
     }
 
     fs::path dataPath =
-        std::filesystem::path(TOSTRING(TEST_DATA_RESOURCE_PATH), fs::path::native_format);
+        std::filesystem::path(TOSTRING(TEST_HVT_DATA_PATH), fs::path::native_format);
     dataPath.append("Data");
     _backend->setDataPath(dataPath);
 

--- a/test/data/baselines/compose_ComposeTask2_android.png
+++ b/test/data/baselines/compose_ComposeTask2_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:093ab7382d90577dd38ae0faaccb4bd0e6f69ba495618772524bb556f51b5e2b
+size 7101

--- a/test/data/baselines/compose_ComposeTask2_designforipad_ios.png
+++ b/test/data/baselines/compose_ComposeTask2_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e6c9be68f816b855f47413924c14928a4425ecdf91d1ef56b6335faec8bcf48
+size 7978

--- a/test/data/baselines/compose_ComposeTask3_android.png
+++ b/test/data/baselines/compose_ComposeTask3_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71bae05f3d4003711b943e318b31522c5cab70661244c46994bb815657e19ab
+size 7052

--- a/test/data/baselines/compose_ComposeTask3_designforipad_ios.png
+++ b/test/data/baselines/compose_ComposeTask3_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34efcc80988fffa49f76b1d2ae8167802386c517e9fd1fa7c21cb35e47d87e1b
+size 7885

--- a/test/data/baselines/compose_ShareTextures4_android.png
+++ b/test/data/baselines/compose_ShareTextures4_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5a6f9c9dbbce799c94a91734911d84e3b4d1d5508867ca7354fd11bcc60902e
+size 6968

--- a/test/data/baselines/compose_ShareTextures4_designforipad_ios.png
+++ b/test/data/baselines/compose_ShareTextures4_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1becfb67bbba3f4f5dbc36fffa19c0396cacb3c91366a458e7d8b9179274741
+size 7886

--- a/test/data/baselines/howTo/createACustomRenderTask_android.png
+++ b/test/data/baselines/howTo/createACustomRenderTask_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c2ffc0b5fe2beaba48b3ba4a0c8d65d1937e0e6b57b10cebd238a4cfea8c65
+size 12078

--- a/test/data/baselines/howTo/createMinimalListOfTasks_android.png
+++ b/test/data/baselines/howTo/createMinimalListOfTasks_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1987ce2be14b40717dfc457bd2d541b442209c9b182f6063993919c080c8bbe8
+size 6430

--- a/test/data/baselines/howTo/createMinimalListOfTasks_designforipad_ios.png
+++ b/test/data/baselines/howTo/createMinimalListOfTasks_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f5a7dbdaab17054ea4e6826a3ec28399d68736ef22ba3ed5a21b5bf43a1814c
+size 7369

--- a/test/data/baselines/howTo/createMinimalListOfTasks_ios.png
+++ b/test/data/baselines/howTo/createMinimalListOfTasks_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c122ae071930accbeffde781e984a93f25e84b0fb65eabe483709265392899b
+size 1295

--- a/test/data/baselines/howTo/createOneFramePass_android.png
+++ b/test/data/baselines/howTo/createOneFramePass_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36d1d49eb05ec51c35f1a3b8e986cafe88d49457bd3b7b9bfe3bc31c587d5455
+size 6018

--- a/test/data/baselines/howTo/createOneFramePass_designforipad_ios.png
+++ b/test/data/baselines/howTo/createOneFramePass_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/howTo/createOneFramePass_ios.png
+++ b/test/data/baselines/howTo/createOneFramePass_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/howTo/createTwoFramePasses_android.png
+++ b/test/data/baselines/howTo/createTwoFramePasses_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36d1d49eb05ec51c35f1a3b8e986cafe88d49457bd3b7b9bfe3bc31c587d5455
+size 6018

--- a/test/data/baselines/howTo/createTwoFramePasses_designforipad_ios.png
+++ b/test/data/baselines/howTo/createTwoFramePasses_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18f2b483516659c6712065f3ecdc85f2b66629443a91f56299d80c336a9f34db
+size 7704

--- a/test/data/baselines/howTo/createTwoFramePasses_ios.png
+++ b/test/data/baselines/howTo/createTwoFramePasses_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18f2b483516659c6712065f3ecdc85f2b66629443a91f56299d80c336a9f34db
+size 7704

--- a/test/data/baselines/howTo/useBoundingBoxSceneIndexFilter_designforipad_ios.png
+++ b/test/data/baselines/howTo/useBoundingBoxSceneIndexFilter_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9784f8db887d20c98571fa5b52a849a070040efd40dc240e039893d856115fc1
+size 3193

--- a/test/data/baselines/howTo/useCollectionToExclude_designforipad_ios.png
+++ b/test/data/baselines/howTo/useCollectionToExclude_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/howTo/useCollectionToInclude_designforipad_ios.png
+++ b/test/data/baselines/howTo/useCollectionToInclude_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d6c3b80c953a98eb3ae03b870ffa4756c14589c91e733ca4140b725ee86a149
+size 3508

--- a/test/data/baselines/howTo/useFXAARenderTask_android.png
+++ b/test/data/baselines/howTo/useFXAARenderTask_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff67f2902b354af40a0f44fc0c870d9f2e70fce09ca5da576d37b16a511c23e4
+size 8577

--- a/test/data/baselines/howTo/useSSAORenderTask_android.png
+++ b/test/data/baselines/howTo/useSSAORenderTask_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6887a8b6323b111da2406e1c1a0fc3ca10c6439d5bedeb0af969e88c3902152
+size 5294

--- a/test/data/baselines/testFramePasses_MainOnly_android.png
+++ b/test/data/baselines/testFramePasses_MainOnly_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b965ff76b76859d518d1d7993fc51123b0684a85a875a43d8baa8072e34db956
+size 6060

--- a/test/data/baselines/testFramePasses_MainOnly_designforipad_ios.png
+++ b/test/data/baselines/testFramePasses_MainOnly_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/testFramePasses_MainOnly_ios.png
+++ b/test/data/baselines/testFramePasses_MainOnly_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/testFramePasses_MainWithBlur_android.png
+++ b/test/data/baselines/testFramePasses_MainWithBlur_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c2ffc0b5fe2beaba48b3ba4a0c8d65d1937e0e6b57b10cebd238a4cfea8c65
+size 12078

--- a/test/data/baselines/testFramePasses_MainWithBlur_designforipad_ios.png
+++ b/test/data/baselines/testFramePasses_MainWithBlur_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ea35e6244905fbfe60f616b355f52cdd8f714ea712812ce912b2f7c6eeb5db
+size 13507

--- a/test/data/baselines/testFramePasses_MainWithBlur_ios.png
+++ b/test/data/baselines/testFramePasses_MainWithBlur_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc43c43a59b16f0736093d9fc153b5557792587b5d22fdb59a391644617453a3
+size 13637

--- a/test/data/baselines/testFramePasses_MainWithFxaa_android.png
+++ b/test/data/baselines/testFramePasses_MainWithFxaa_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff67f2902b354af40a0f44fc0c870d9f2e70fce09ca5da576d37b16a511c23e4
+size 8577

--- a/test/data/baselines/testFramePasses_MainWithFxaa_ios.png
+++ b/test/data/baselines/testFramePasses_MainWithFxaa_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4af4ffc8fe1ccc7ec5b1193feb6c85d099ab25ed0ac70665695536dde58c9d48
+size 12235

--- a/test/data/baselines/testFramePasses_SceneIndex_android.png
+++ b/test/data/baselines/testFramePasses_SceneIndex_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b965ff76b76859d518d1d7993fc51123b0684a85a875a43d8baa8072e34db956
+size 6060

--- a/test/data/baselines/testFramePasses_SceneIndex_designforipad_ios.png
+++ b/test/data/baselines/testFramePasses_SceneIndex_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/testFramePasses_SceneIndex_ios.png
+++ b/test/data/baselines/testFramePasses_SceneIndex_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67454a42bc5befec54ee5301d2ea7a6ac5f5674c7d6c3b2252f1d5d74670f149
+size 6326

--- a/test/data/baselines/testSearchFaces_android.png
+++ b/test/data/baselines/testSearchFaces_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a3ca92782161b6e757bca629a4e09451b16f00ccb09dd3bc562730f77200574
+size 23017

--- a/test/data/baselines/testSearchFaces_ios.png
+++ b/test/data/baselines/testSearchFaces_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:640c78d829e6c87282eef046056bead7d36e3e06fa5642af895530bb913de929
+size 16039

--- a/test/data/baselines/testSearchPrims_android.png
+++ b/test/data/baselines/testSearchPrims_android.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e817e67877e23fa00a9e162fbb9316d1dc3086a0ae33340d0b598da2f92b714c
+size 14681

--- a/test/data/baselines/testSearchPrims_ios.png
+++ b/test/data/baselines/testSearchPrims_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a213ca45f16d08e8dab58e5069c2c8d3f657d3fe459f7228640162c92a4f56de
+size 11823


### PR DESCRIPTION
To keep all HVT test information together, android and iOS baselines are added. We also update the paths for tests.