### PR TITLE
OGSMOD-7567 - Prep. work for the HVT CI/CD

### DIFF
--- a/test/howTos/howTo03_CreateTwoFramePasses.cpp
+++ b/test/howTos/howTo03_CreateTwoFramePasses.cpp
@@ -31,7 +31,8 @@
 
 // TODO: Vulkan  introduces result inconsistencies.
 // TODO: Linux result image could have one pixel difference between runs. Refer to OGSMOD-6304
-#if (TARGET_OS_IPHONE == 1) || (defined(_WIN32) && defined(ENABLE_VULKAN)) || defined(__linux__)
+// NOTE: With 'origin/dev', the tripod axis is too far (or too small). That's fixed in 'adsk/dev' . 
+#if (TARGET_OS_IPHONE == 1) || (defined(_WIN32) && defined(ENABLE_VULKAN)) || defined(__linux__) || !defined(ADSK_OPENUSD_PENDING)
 TEST(howTo, DISABLED_createTwoFramePasses)
 #else
 TEST(howTo, createTwoFramePasses)


### PR DESCRIPTION
The pull request disables one unit test when compiling with OpenUSD `origin/dev` because it needs a `adsk/dev` feature to succeed.