### PR TITLE
As we move DashDotLines to a separate rprim, we will not build the BasisCurves with style.

### DIFF
--- a/include/hvt/geometry/geometry.h
+++ b/include/hvt/geometry/geometry.h
@@ -272,14 +272,6 @@ HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildBasisCurvesDS(
     const PXR_NS::VtArray<int>& vertexCounts, const PXR_NS::VtArray<int>& curveIndices,
     const PXR_NS::TfToken& basis = PXR_NS::HdTokens->bezier,
     const PXR_NS::TfToken& type  = PXR_NS::HdTokens->linear,
-    const PXR_NS::TfToken& wrap  = PXR_NS::HdTokens->nonperiodic,
-// ADSK: For pending changes to OpenUSD from Autodesk: line styles.
-#if defined(ADSK_OPENUSD_PENDING)
-    const PXR_NS::TfToken& style = PXR_NS::HdTokens->none,
-
-#else
-    const PXR_NS::TfToken& style = PXR_NS::HdTokens->linear, // dummy value - is ifdef'd out in .cpp
-#endif
-    bool hasPixelScale = false); // line style
+    const PXR_NS::TfToken& wrap  = PXR_NS::HdTokens->nonperiodic);
 
 } // namespace HVT_NS

--- a/source/geometry/geometry.cpp
+++ b/source/geometry/geometry.cpp
@@ -175,8 +175,7 @@ HdContainerDataSourceHandle BuildMeshDS(const VtArray<int>& vertexCounts,
 
 HdContainerDataSourceHandle BuildBasisCurvesDS(const VtArray<int>& vertexCounts,
     const VtArray<int>& curveIndices, const TfToken& basis, const TfToken& type,
-    const TfToken& wrap, [[maybe_unused]] const TfToken& style, 
-    [[maybe_unused]] bool hasPixelScale)
+    const TfToken& wrap)
 {
     const HdContainerDataSourceHandle topoDs =
         HdBasisCurvesTopologySchema::Builder()
@@ -185,11 +184,6 @@ HdContainerDataSourceHandle BuildBasisCurvesDS(const VtArray<int>& vertexCounts,
             .SetBasis(_TokenDs::New(basis)) // bspline, catmullRom
             .SetType(_TokenDs::New(type))   // cubic
             .SetWrap(_TokenDs::New(wrap))   // pinned, periodic, nonperiodic
-// ADSK: For pending changes to OpenUSD from Autodesk: line styles.
-#if defined(ADSK_OPENUSD_PENDING)
-            .SetStyle(_TokenDs::New(style)) // this is adsk branch only
-            .SetHasPixelScale(HdRetainedTypedSampledDataSource<bool>::New(hasPixelScale))
-#endif
             .Build();
 
     return HdBasisCurvesSchema::Builder().SetTopology(topoDs).Build();


### PR DESCRIPTION
As we move DashDotLines to a separate rprim, we will not build the BasisCurves with style.