### PR TITLE
OGSMOD-7634: Add missing IOS baseline for increased test coverage.

### DIFF
--- a/test/data/baselines/TestFramePasses_TestDynamicAovInputs_designforipad_ios.png
+++ b/test/data/baselines/TestFramePasses_TestDynamicAovInputs_designforipad_ios.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ac4b29e058a95eb2cc154e13d7acb2585294ea4c41941b8c9fba94f08dc3c88
+size 10655


### PR DESCRIPTION
The unit test coverage was recently increased to include more IOS checks.
This new baseline image will be used as a reference.