### PR TITLE
AGPMAT-5: Add API updateMaterial for material property change

### DIFF
--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -157,6 +157,13 @@ public:
     /// @return True on success.
     virtual bool bindMaterial(const PXR_NS::SdfPath& primPath, const PXR_NS::VtValue& mtlxDocument);
 
+    /// @brief Update the value of specified material and property.
+    /// @param matPrimPath Path of the material prim.
+    /// @param prop Token of property and relationship
+    /// @param newPropValue  New value of the given material property
+    /// @return True on success.
+    virtual bool updateMaterial(const PXR_NS::SdfPath& matPrimPath, const PXR_NS::TfToken& prop, const PXR_NS::VtValue& newPropValue);
+
     /// Returns true if the path is a primitive in the scene.
     /// \param path The primitive path.
     virtual bool isPrimitive(const PXR_NS::SdfPath& path) const;

--- a/source/dataSource/dataSource.cpp
+++ b/source/dataSource/dataSource.cpp
@@ -70,6 +70,12 @@ bool SceneDataSource::bindMaterial(const SdfPath& /* primPath */, const VtValue&
     return false;
 }
 
+bool SceneDataSource::updateMaterial(const SdfPath& /*matPrimPath*/, const TfToken& /*prop*/, const VtValue& /*newPropValue*/)
+{
+    TF_RUNTIME_ERROR("No implementation for SceneDataSource::updateMaterial()");
+    return false;
+}
+
 bool SceneDataSource::isPrimitive(const SdfPath& /* path */) const
 {
     return false;


### PR DESCRIPTION
The existing `bindMaterial` is relatively expensive because it needs to dirty all affected rPrims and re-compile material shader.
In order to support MaterialX editing and avoid to rebind MaterialX to rPrim, I proposed this new API. 