### PR TITLE
Add a pixelCountThreshold to the compareImages functions

### DIFF
--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -142,29 +142,30 @@ std::string HydraRendererContext::getFilename(
     return fullFilepath;
 };
 
-bool HydraRendererContext::compareImages(const std::string& fileName, const uint8_t threshold)
+bool HydraRendererContext::compareImages(
+    const std::string& fileName, const uint8_t threshold, const uint8_t pixelCountThreshold)
 {
     std::string inFileName    = fileName;
     const auto baselinePath   = getBaselineFolder();
     const std::string inFile  = getFilename(baselinePath, inFileName);
     const std::string outFile = getFilename(outFullpath, fileName + "_computed");
 
-    return compareImages(inFile, outFile, threshold);
+    return compareImages(inFile, outFile, threshold, pixelCountThreshold);
 }
 
-bool HydraRendererContext::compareOutputImages(
-    const std::string& fileName1, const std::string& fileName2, const uint8_t threshold)
+bool HydraRendererContext::compareOutputImages(const std::string& fileName1,
+    const std::string& fileName2, const uint8_t threshold, const uint8_t pixelCountThreshold)
 {
     const std::string file1 = getFilename(outFullpath, fileName1 + "_computed");
     const std::string file2 = getFilename(outFullpath, fileName2 + "_computed");
 
-    return compareImages(file1, file2, threshold);
+    return compareImages(file1, file2, threshold, pixelCountThreshold);
 }
 
-bool HydraRendererContext::compareImages(
-    const std::string& inFile, const std::string& outFile, const uint8_t threshold)
+bool HydraRendererContext::compareImages(const std::string& inFile, const std::string& outFile,
+    const uint8_t threshold, const uint8_t pixelCountThreshold)
 {
-    return RenderingUtils::compareImages(inFile, outFile, threshold);
+    return RenderingUtils::compareImages(inFile, outFile, threshold, pixelCountThreshold);
 }
 
 void HydraRendererContext::createHGI([[maybe_unused]] pxr::TfToken type)

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -118,13 +118,14 @@ public:
         const std::filesystem::path& filePath, const std::string& filename);
 
     /// Compare image against stored "_computed" image and throws if a difference is found within
-    /// the threshold defined.
-    virtual bool compareImages(const std::string& fileName, const uint8_t threshold = 1);
+    /// the thresholds defined.
+    virtual bool compareImages(const std::string& fileName, const uint8_t threshold = 1,
+        const uint8_t pixelCountThreshold = 0);
 
-    /// Compare two "_computed" images and throws if a difference is found within the threshold
+    /// Compare two "_computed" images and throws if a difference is found within the thresholds
     /// defined
-    virtual bool compareOutputImages(
-        const std::string& fileName1, const std::string& fileName2, const uint8_t threshold = 1);
+    virtual bool compareOutputImages(const std::string& fileName1, const std::string& fileName2,
+        const uint8_t threshold = 1, const uint8_t pixelCountThreshold = 0);
 
     virtual void setDataPath(const std::filesystem::path& path) { _dataPath = path; }
     virtual const std::filesystem::path& dataPath() const { return _dataPath; }
@@ -143,9 +144,10 @@ protected:
     /// \note It requires full paths.
     /// \param fileName1 The first file to compare.
     /// \param fileName2 The second file to compare.
-    /// \param threshold The comparison threshold.
-    virtual bool compareImages(
-        const std::string& fileName1, const std::string& fileName2, const uint8_t threshold);
+    /// \param threshold The comparison threshold for pixel value differences.
+    /// \param pixelCountThreshold The comparison threshold for pixel count differences.
+    virtual bool compareImages(const std::string& fileName1, const std::string& fileName2,
+        const uint8_t threshold, const uint8_t pixelCountThreshold);
 
 private:
     int _width  = 1;

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 by Autodesk, Inc.  All rights reserved.
+// Copyright 2025 by Autodesk, Inc.  All rights reserved.
 //
 // This computer source code and related instructions and comments
 // are the unpublished confidential and proprietary information of

--- a/test/RenderingUtils/ImageUtils.cpp
+++ b/test/RenderingUtils/ImageUtils.cpp
@@ -54,7 +54,8 @@ std::string readImage(const std::string& filePath, int& width, int& height, int&
     return data;
 }
 
-bool compareImages(const std::string& filePath1, const std::string& filePath2, uint8_t threshold)
+bool compareImages(const std::string& filePath1, const std::string& filePath2, uint8_t threshold,
+    uint8_t pixelCountThreshold)
 {
     // A simple structure that reads a image file using STB.
     struct LoadPNG
@@ -137,7 +138,7 @@ bool compareImages(const std::string& filePath1, const std::string& filePath2, u
 
     // If the threshold was exceeded for one or more pixel comparisons, then create a readable
     // string report and throw an exception with the report.
-    if (countPixelDiff > 0)
+    if (countPixelDiff > pixelCountThreshold)
     {
         float percentDiff = (100.0f * countPixelDiff) / (width1 * height1);
         std::stringstream str;

--- a/test/RenderingUtils/ImageUtils.cpp
+++ b/test/RenderingUtils/ImageUtils.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 by Autodesk, Inc.  All rights reserved.
+// Copyright 2025 by Autodesk, Inc.  All rights reserved.
 //
 // This computer source code and related instructions and comments
 // are the unpublished confidential and proprietary information of
@@ -87,7 +87,8 @@ bool compareImages(const std::string& filePath1, const std::string& filePath2, u
 
     // Function that compares data for two pixels and returns the maximum value difference between
     // them among the available channels. For example, [10,10,10,255] vs. [12,10,10,255] returns 2.
-    auto fnDiff = [](uint8_t pix1[], uint8_t pix2[], int numChannels) -> int {
+    auto fnDiff = [](uint8_t pix1[], uint8_t pix2[], int numChannels) -> int
+    {
         int maxDiff = 0;
         for (int i = 0; i < numChannels; i++)
         {
@@ -136,8 +137,8 @@ bool compareImages(const std::string& filePath1, const std::string& filePath2, u
         }
     }
 
-    // If the threshold was exceeded for one or more pixel comparisons, then create a readable
-    // string report and throw an exception with the report.
+    // If the threshold was exceeded for more pixels than the pixel count threshold, then create a
+    // readable string report and throw an exception with the report.
     if (countPixelDiff > pixelCountThreshold)
     {
         float percentDiff = (100.0f * countPixelDiff) / (width1 * height1);

--- a/test/RenderingUtils/ImageUtils.h
+++ b/test/RenderingUtils/ImageUtils.h
@@ -11,23 +11,23 @@
 #pragma once
 
 #if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#pragma clang diagnostic ignored "-Wunused-parameter"
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #pragma clang diagnostic ignored "-Wunused-parameter"
 #elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#pragma warning(disable : 4305)
-#pragma warning(disable : 4275)
-#pragma warning(disable : 4100)
+    #pragma warning(push)
+    #pragma warning(disable : 4244)
+    #pragma warning(disable : 4305)
+    #pragma warning(disable : 4275)
+    #pragma warning(disable : 4100)
 #endif
 
 #include <pxr/base/gf/matrix4d.h>
 
 #if __clang__
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #elif defined(_MSC_VER)
-#pragma warning(pop)
+    #pragma warning(pop)
 #endif
 
 #include <cmath>
@@ -83,10 +83,11 @@ std::string readImage(const std::string& filePath, int& width, int& height, int&
 
 /// Compares two images using a threshold.
 ///
-/// Returns true if the images are similar and throws an exception if one of more pixels differ
-/// by the more than the threshold amount in one or more channels.
-bool compareImages(
-    const std::string& filePath1, const std::string& filePath2, uint8_t threshold = 1);
+/// Returns true if the images are similar and throws an exception if more than the number pixels
+/// defined by the pixelCountThreshhold differ by more than the threshold amount in one or more
+/// channels.
+bool compareImages(const std::string& filePath1, const std::string& filePath2,
+    uint8_t threshold = 1, uint8_t pixelCountThreshold = 0);
 
 } // namespace RenderingUtils
 

--- a/test/RenderingUtils/ImageUtils.h
+++ b/test/RenderingUtils/ImageUtils.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 by Autodesk, Inc.  All rights reserved.
+// Copyright 2025 by Autodesk, Inc.  All rights reserved.
 //
 // This computer source code and related instructions and comments
 // are the unpublished confidential and proprietary information of
@@ -11,23 +11,23 @@
 #pragma once
 
 #if __clang__
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunused-parameter"
 #elif defined(_MSC_VER)
-    #pragma warning(push)
-    #pragma warning(disable : 4244)
-    #pragma warning(disable : 4305)
-    #pragma warning(disable : 4275)
-    #pragma warning(disable : 4100)
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#pragma warning(disable : 4305)
+#pragma warning(disable : 4275)
+#pragma warning(disable : 4100)
 #endif
 
 #include <pxr/base/gf/matrix4d.h>
 
 #if __clang__
-    #pragma clang diagnostic pop
+#pragma clang diagnostic pop
 #elif defined(_MSC_VER)
-    #pragma warning(pop)
+#pragma warning(pop)
 #endif
 
 #include <cmath>


### PR DESCRIPTION
Sometimes it is more important to ignore a small number of pixel differences instead of value differences. (Rasterization inconsistencies)