### PR TITLE
OGSMOD-7804: Make Neye FramePass render output optional.

### DIFF
--- a/include/hvt/engine/framePass.h
+++ b/include/hvt/engine/framePass.h
@@ -136,6 +136,10 @@ struct HVT_API FramePassParams : public BasicLayerParams
     bool enableMultisampling { true };
     size_t msaaSampleCount { 4 };
     /// @}
+
+    /// Enable eye relative normal render output.
+    /// NOTE: this adds an extra cost for all geometry render passes.
+    bool enableNeyeRenderOutput { false };
 };
 
 /// A FramePass is used to render or select from a collection of Prims using a set of HdTasks and

--- a/source/engine/framePass.cpp
+++ b/source/engine/framePass.cpp
@@ -292,9 +292,14 @@ HdTaskSharedPtrVector FramePass::GetRenderTasks(RenderBufferBindings const& inpu
     {
         if (!IsStormRenderDelegate(GetRenderIndex()) || params().enableOutline)
             renderOutputs = { HdAovTokens->color, HdAovTokens->depth, HdAovTokens->primId,
-                HdAovTokens->elementId, HdAovTokens->instanceId, HdAovTokens->Neye };
+                HdAovTokens->elementId, HdAovTokens->instanceId};
         else
-            renderOutputs = { HdAovTokens->color, HdAovTokens->depth, HdAovTokens->Neye };
+            renderOutputs = { HdAovTokens->color, HdAovTokens->depth};
+
+        if (_passParams.enableNeyeRenderOutput)
+        {
+            renderOutputs.push_back(HdAovTokens->Neye);
+        }
     }
 
     _bufferManager->SetRenderOutputs(renderOutputs, inputAOVs, {});


### PR DESCRIPTION
Adding Neye render output to all frame passes has a significant performance cost.
Therefore, we make it optional.