### PR TITLE
OGSMOD-7751: Bump HVT version and align with updated USD release.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 # Declare the project.
 project(HydraViewportToolbox
-    VERSION     0.25.03.0
+    VERSION     0.25.08.1
     DESCRIPTION "Utilities to support graphics viewports using OpenUSD Hydra"
     LANGUAGES   CXX
 )


### PR DESCRIPTION
Update version of HVT and use a format that can be matched with USD releases.

This version number must always match the version numer in `USD\include\pxr\pxr.h` with which HVT was tested.