### PR TITLE
Various fixes for build support on different platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,11 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "[C|c]lang" OR CMAKE_CXX_COMPILER_ID MATCHE
     # By default, enables all warnings.
     add_compile_options(-Wall -Wextra -Wpedantic)
 
+    # Needed to avoid a warning caused by pxr/base/tf/hashset.h
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-Wno-deprecated)
+    endif()
+
     if (ENABLE_WARNINGS_AS_ERRORS)
         add_compile_options(-Werror)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "[C|c]lang" OR CMAKE_CXX_COMPILER_ID MATCHE
     # By default, enables all warnings.
     add_compile_options(-Wall -Wextra -Wpedantic)
 
-    # Needed to avoid a warning caused by pxr/base/tf/hashset.h
+    # USD's pxr/base/tf/hashset.h uses the GNU STL extensions hashset,
+    # which generates a warning that is then reported as an error.
+    # Pending a change in USD, disable the warning here for now.
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         add_compile_options(-Wno-deprecated)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if (MSVC)
     # link against the release version of the Python lib, causing a linker error :
     # https://github.com/python/cpython/blob/v3.11.4/PC/pyconfig.h#L269-L286
     add_compile_definitions(
-	    $<$<CONFIG:Debug>:BOOST_DEBUG_PYTHON>
+        $<$<CONFIG:Debug>:BOOST_DEBUG_PYTHON>
     )
 
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "[C|c]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,16 @@ if (MSVC)
     # prevent the conflict, we can specify the NOMINMAX symbol since we don't use the macros.
     add_compile_definitions(NOMINMAX)
 
+    # In debug builds, Boost's wrap_python.hpp will #undef _DEBUG when BOOST_DEBUG_PYTHON is not defined,
+    # and will then include pyconfig.h :
+    # https://github.com/boostorg/python/blob/boost-1.81.0/include/boost/python/detail/wrap_python.hpp#L23-L57
+    # pyconfig.h will then autolink the Python lib; however, since _DEBUG was #undef'd, it will try to
+    # link against the release version of the Python lib, causing a linker error :
+    # https://github.com/python/cpython/blob/v3.11.4/PC/pyconfig.h#L269-L286
+    add_compile_definitions(
+	    $<$<CONFIG:Debug>:BOOST_DEBUG_PYTHON>
+    )
+
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "[C|c]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
     # By default, enables all warnings.

--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -67,7 +67,7 @@ namespace HVT_NS
 {
 
 /// Represents whether we're optimized for viewing, or capable of editing.
-enum HVT_API ViewingMode
+enum ViewingMode
 {
     PerformantViewing = 0,
     Editable


### PR DESCRIPTION
This PR implements a few tweaks to allow HVT to compile across a broader range of targets.