### PR TITLE
[Draft] OGSMOD-7842: Remove nEye from AovInputTask and from RenderBufferManager

### DIFF
--- a/include/hvt/engine/renderBufferSettingsProvider.h
+++ b/include/hvt/engine/renderBufferSettingsProvider.h
@@ -58,10 +58,8 @@ struct HVT_API AovParams
     /// @{
     PXR_NS::SdfPath aovBufferPath;
     PXR_NS::SdfPath depthBufferPath;
-    PXR_NS::SdfPath neyeBufferPath;
     PXR_NS::HdRenderBuffer* aovBuffer   = nullptr;
     PXR_NS::HdRenderBuffer* depthBuffer = nullptr;
-    PXR_NS::HdRenderBuffer* neyeBuffer  = nullptr;
     /// @}
 
     /// The framebuffer that the AOVs are presented into. This is a VtValue that encodes a

--- a/include/hvt/tasks/aovInputTask.h
+++ b/include/hvt/tasks/aovInputTask.h
@@ -92,28 +92,24 @@ private:
 
     PXR_NS::HdRenderBuffer* _aovBuffer { nullptr };
     PXR_NS::HdRenderBuffer* _depthBuffer { nullptr };
-    PXR_NS::HdRenderBuffer* _neyeBuffer { nullptr };
 
     PXR_NS::HgiTextureHandle _aovTexture;
     PXR_NS::HgiTextureHandle _depthTexture;
     PXR_NS::HgiTextureHandle _aovTextureIntermediate;
-    PXR_NS::HgiTextureHandle _neyeTexture;
 };
 
 /// AovInput parameters.
 struct HVT_API AovInputTaskParams
 {
     AovInputTaskParams() :
-        aovBufferPath(), depthBufferPath(), aovBuffer(nullptr), depthBuffer(nullptr), neyeBuffer(nullptr)
+        aovBufferPath(), depthBufferPath(), aovBuffer(nullptr), depthBuffer(nullptr)
     {
     }
 
     PXR_NS::SdfPath aovBufferPath;
     PXR_NS::SdfPath depthBufferPath;
-    PXR_NS::SdfPath neyeBufferPath;
     PXR_NS::HdRenderBuffer* aovBuffer;
     PXR_NS::HdRenderBuffer* depthBuffer;
-    PXR_NS::HdRenderBuffer* neyeBuffer;
 };
 
 /// VtValue requirements

--- a/source/engine/renderBufferManager.cpp
+++ b/source/engine/renderBufferManager.cpp
@@ -141,8 +141,7 @@ public:
 private:
     /// Sets the viewport render output (color or buffer visualization).
     void SetViewportRenderOutput(const TfToken& name, HdRenderBuffer* aovBuffer,
-        HdRenderBuffer* depthBuffer, PXR_NS::HdRenderBuffer* neyeBuffer,
-        const SdfPath& controllerId);
+        HdRenderBuffer* depthBuffer, const SdfPath& controllerId);
 
     /// Resets the clear values
     void ResetRenderOutputClear();
@@ -387,7 +386,6 @@ bool RenderBufferManager::Impl::SetRenderOutputs(const TfTokenVector& outputs,
     {
         HdRenderBuffer* firstInput = nullptr;
         HdRenderBuffer* depthInput = nullptr;
-        HdRenderBuffer* neyeInput  = nullptr;
         for (auto input : inputs)
         {
             // This is super fragile and limited.
@@ -396,10 +394,8 @@ bool RenderBufferManager::Impl::SetRenderOutputs(const TfTokenVector& outputs,
                 firstInput = input.second;
             if (input.first == "depth")
                 depthInput = input.second;
-            if (input.first == HdAovTokens->Neye)
-                neyeInput = input.second;
         }
-        SetViewportRenderOutput(localOutputs[0], firstInput, depthInput, neyeInput, controllerId);
+        SetViewportRenderOutput(localOutputs[0], firstInput, depthInput, controllerId);
     }
 
     // NOTE: The viewport data plumbed to tasks unfortunately depends on whether aovs are being
@@ -408,8 +404,7 @@ bool RenderBufferManager::Impl::SetRenderOutputs(const TfTokenVector& outputs,
 }
 
 void RenderBufferManager::Impl::SetViewportRenderOutput(TfToken const& name,
-    HdRenderBuffer* aovBuffer, HdRenderBuffer* depthBuffer, PXR_NS::HdRenderBuffer* neyeBuffer,
-    const SdfPath& controllerId)
+    HdRenderBuffer* aovBuffer, HdRenderBuffer* depthBuffer, const SdfPath& controllerId)
 {
     if (!IsAovSupported())
     {
@@ -426,16 +421,13 @@ void RenderBufferManager::Impl::SetViewportRenderOutput(TfToken const& name,
     {
         _aovTaskCache.aovBufferPath   = SdfPath::EmptyPath();
         _aovTaskCache.depthBufferPath = SdfPath::EmptyPath();
-        _aovTaskCache.neyeBufferPath  = SdfPath::EmptyPath();
         _aovTaskCache.aovBuffer       = nullptr;
         _aovTaskCache.depthBuffer     = nullptr;
-        _aovTaskCache.neyeBuffer      = nullptr;
     }
     else if (name == HdAovTokens->color)
     {
         _aovTaskCache.aovBufferPath   = GetAovPath(controllerId, HdAovTokens->color);
         _aovTaskCache.depthBufferPath = GetAovPath(controllerId, HdAovTokens->depth);
-        _aovTaskCache.neyeBufferPath  = GetAovPath(controllerId, HdAovTokens->Neye);
         _aovTaskCache.aovBuffer       = aovBuffer
                   ? aovBuffer
                   : static_cast<HdRenderBuffer*>(_pRenderIndex->GetBprim(
@@ -445,21 +437,14 @@ void RenderBufferManager::Impl::SetViewportRenderOutput(TfToken const& name,
             ? depthBuffer
             : static_cast<HdRenderBuffer*>(_pRenderIndex->GetBprim(
                   HdPrimTypeTokens->renderBuffer, _aovTaskCache.depthBufferPath));
-
-        _aovTaskCache.neyeBuffer = neyeBuffer
-            ? neyeBuffer
-            : static_cast<HdRenderBuffer*>(_pRenderIndex->GetBprim(
-                  HdPrimTypeTokens->renderBuffer, _aovTaskCache.neyeBufferPath));
     }
     else
     {
         // When visualizing a buffer other than color, this condition is executed.
         _aovTaskCache.aovBufferPath   = GetAovPath(controllerId, name);
         _aovTaskCache.depthBufferPath = SdfPath::EmptyPath();        
-        _aovTaskCache.neyeBufferPath  = SdfPath::EmptyPath();
         _aovTaskCache.aovBuffer       = aovBuffer ? aovBuffer : GetRenderOutput(name, controllerId);
         _aovTaskCache.depthBuffer     = nullptr;
-        _aovTaskCache.neyeBuffer      = nullptr;
     }
 }
 

--- a/source/engine/taskCreationHelpers.cpp
+++ b/source/engine/taskCreationHelpers.cpp
@@ -584,10 +584,8 @@ SdfPath CreateAovInputTask(
             AovInputTaskParams params;
             params.aovBufferPath   = aovData.aovBufferPath;
             params.depthBufferPath = aovData.depthBufferPath;
-            params.neyeBufferPath  = aovData.neyeBufferPath;
             params.aovBuffer       = aovData.aovBuffer;
             params.depthBuffer     = aovData.depthBuffer;
-            params.neyeBuffer      = aovData.neyeBuffer;
             fnSetValue(HdTokens->params, VtValue(params));
         }
     };

--- a/source/tasks/aovInputTask.cpp
+++ b/source/tasks/aovInputTask.cpp
@@ -48,7 +48,7 @@ namespace HVT_NS
 {
 
 AovInputTask::AovInputTask(HdSceneDelegate* /* delegate */, SdfPath const& id) :
-    HdxTask(id), _converged(false), _aovBuffer(nullptr), _depthBuffer(nullptr), _neyeBuffer(nullptr)
+    HdxTask(id), _converged(false), _aovBuffer(nullptr), _depthBuffer(nullptr)
 {
 }
 
@@ -65,10 +65,6 @@ AovInputTask::~AovInputTask()
     if (_depthTexture)
     {
         _GetHgi()->DestroyTexture(&_depthTexture);
-    }
-    if (_neyeTexture)
-    {
-        _GetHgi()->DestroyTexture(&_neyeTexture);
     }
 }
 
@@ -91,7 +87,6 @@ void AovInputTask::_Sync(
         {
             _aovBuffer   = params.aovBuffer;
             _depthBuffer = params.depthBuffer;
-            _neyeBuffer  = params.neyeBuffer;
         }
     }
     *dirtyBits = HdChangeTracker::Clean;
@@ -131,20 +126,12 @@ void AovInputTask::Execute(HdTaskContext* ctx)
     {
         _converged = _converged && _depthBuffer->IsConverged();
     }
-    if (_neyeBuffer)
-    {
-        _converged = _converged && _neyeBuffer->IsConverged();
-    }
 
     // Resolve the buffers before we read them.
     _aovBuffer->Resolve();
     if (_depthBuffer)
     {
         _depthBuffer->Resolve();
-    }
-    if (_neyeBuffer)
-    {
-        _neyeBuffer->Resolve();
     }
 
     static const TfToken msaaToken("colorMSAA");
@@ -154,7 +141,6 @@ void AovInputTask::Execute(HdTaskContext* ctx)
     ctx->erase(HdAovTokens->color);
     ctx->erase(HdAovTokens->depth);
     ctx->erase(HdxAovTokens->colorIntermediate);
-    ctx->erase(HdAovTokens->Neye);
     ctx->erase(msaaToken);
 
     // If the aov is already backed by a HgiTexture we skip creating a new
@@ -184,15 +170,6 @@ void AovInputTask::Execute(HdTaskContext* ctx)
         }
     }
 
-    if (_neyeBuffer)
-    {
-        VtValue neye = _neyeBuffer->GetResource(mulSmp);
-        if (neye.IsHolding<HgiTextureHandle>())
-        {
-            (*ctx)[HdAovTokens->Neye] = neye;
-        }
-    }
-
     if (hgiHandleProvidedByAov)
     {
         return;
@@ -215,14 +192,6 @@ void AovInputTask::Execute(HdTaskContext* ctx)
         if (_depthTexture)
         {
             (*ctx)[HdAovTokens->depth] = VtValue(_depthTexture);
-        }
-    }
-    if (_neyeBuffer)
-    {
-        _UpdateTexture(ctx, _neyeTexture, _neyeBuffer, HgiTextureUsageBitsShaderRead);
-        if (_neyeTexture)
-        {
-            (*ctx)[HdAovTokens->Neye] = VtValue(_neyeTexture);
         }
     }
 }


### PR DESCRIPTION
nEye buffer can be accessed from the RenderIndex instead of the TaskContext.