### PR TITLE
Add doubleSided parameter (default false) to BuildMeshDS function

### DIFF
--- a/include/hvt/geometry/geometry.h
+++ b/include/hvt/geometry/geometry.h
@@ -211,21 +211,25 @@ using PolylineDescriptor2d = PolylineDescriptor<PXR_NS::VtVec2fArray>;
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::GfMatrix4d& transform = PXR_NS::GfMatrix4d(1),
-    const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath());
+    const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath(),
+    bool doubleSided = false);
 
 /// Geometry and material creation.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::GfMatrix4f& transform = PXR_NS::GfMatrix4f(1),
-    const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath());
+    const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath(),
+    bool doubleSided = false);
 
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMesh(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
-    const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath());
+    const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath(),
+    bool doubleSided = false);
 
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMesh(
     const MeshDescriptorBase<PXR_NS::VtVec2fArray>& desc,
-    const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath());
+    const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath(),
+    bool doubleSided = false);
 
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreatePolyline(
     const PolylineDescriptorBase<PXR_NS::VtVec3fArray>& desc);
@@ -264,9 +268,11 @@ HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildIndexedPrimvarDS(
     const PXR_NS::VtIntArray& indices    = PXR_NS::VtIntArray());
 
 HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildMeshDS(
-    const PXR_NS::VtArray<int>& vertexCounts, const PXR_NS::VtArray<int>& faceIndices,
+    const PXR_NS::VtArray<int>& vertexCounts,
+    const PXR_NS::VtArray<int>& faceIndices,
     const PXR_NS::VtArray<int>& holeIndices = PXR_NS::VtIntArray(),
-    const PXR_NS::TfToken& orientation      = PXR_NS::HdMeshTopologySchemaTokens->rightHanded);
+    const PXR_NS::TfToken& orientation      = PXR_NS::HdMeshTopologySchemaTokens->rightHanded,
+    bool doubleSided = false);
 
 HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildBasisCurvesDS(
     const PXR_NS::VtArray<int>& vertexCounts, const PXR_NS::VtArray<int>& curveIndices,

--- a/include/hvt/geometry/geometry.h
+++ b/include/hvt/geometry/geometry.h
@@ -58,12 +58,12 @@
 #include <pxr/imaging/hd/retainedSceneIndex.h>
 #include <pxr/imaging/hd/tokens.h>
 
- #if defined(__clang__)
-#pragma clang diagnostic pop
+#if defined(__clang__)
+    #pragma clang diagnostic pop
 #elif defined(_MSC_VER)
-#pragma warning(pop)
+    #pragma warning(pop)
 #elif defined(__GNUC__)
-#pragma GCC diagnostic pop
+    #pragma GCC diagnostic pop
 #endif
 
 namespace HVT_NS
@@ -72,8 +72,8 @@ namespace HVT_NS
 /// Enumeration for mesh sided mode to improve readability over boolean parameters.
 enum class SidedMode
 {
-    SingleSided,  ///< Render only front faces
-    DoubleSided   ///< Render both front and back faces
+    SingleSided, ///< Render only front faces
+    DoubleSided  ///< Render both front and back faces
 };
 
 using PrimvarDescriptors = std::vector<std::pair<PXR_NS::TfToken, PXR_NS::HdDataSourceBaseHandle>>;
@@ -219,52 +219,52 @@ using PolylineDescriptor2d = PolylineDescriptor<PXR_NS::VtVec2fArray>;
 /// \param transform The transformation matrix to apply (default: identity matrix).
 /// \param instancerId Optional instancer ID for instanced rendering.
 /// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
-///                  Warning: DoubleSided mode may impact render performance as it disables
-///                  backface culling and renders both front and back faces.
+/// \note DoubleSided mode may impact render performance as it disables
+///       backface culling and renders both front and back faces.
 /// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::GfMatrix4d& transform = PXR_NS::GfMatrix4d(1),
     const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath(),
-    SidedMode sidedMode = SidedMode::SingleSided);
+    SidedMode sidedMode                 = SidedMode::SingleSided);
 
 /// \brief Creates a 3D mesh with transformation matrix (float precision).
 /// \param desc The mesh descriptor containing geometry data.
 /// \param transform The transformation matrix to apply (default: identity matrix).
 /// \param instancerId Optional instancer ID for instanced rendering.
 /// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
-///                  Warning: DoubleSided mode may impact render performance as it disables
-///                  backface culling and renders both front and back faces.
+/// \note DoubleSided mode may impact render performance as it disables
+///       backface culling and renders both front and back faces.
 /// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::GfMatrix4f& transform = PXR_NS::GfMatrix4f(1),
     const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath(),
-    SidedMode sidedMode = SidedMode::SingleSided);
+    SidedMode sidedMode                 = SidedMode::SingleSided);
 
 /// \brief Creates a 3D mesh without transformation.
 /// \param desc The mesh descriptor containing geometry data.
 /// \param instancerId Optional instancer ID for instanced rendering.
 /// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
-///                  Warning: DoubleSided mode may impact render performance as it disables
-///                  backface culling and renders both front and back faces.
+/// \note DoubleSided mode may impact render performance as it disables
+///       backface culling and renders both front and back faces.
 /// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMesh(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath(),
-    SidedMode sidedMode = SidedMode::SingleSided);
+    SidedMode sidedMode                = SidedMode::SingleSided);
 
 /// \brief Creates a 2D mesh without transformation.
 /// \param desc The mesh descriptor containing geometry data.
 /// \param instancerId Optional instancer ID for instanced rendering.
 /// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
-///                  Warning: DoubleSided mode may impact render performance as it disables
-///                  backface culling and renders both front and back faces.
+/// \note DoubleSided mode may impact render performance as it disables
+///       backface culling and renders both front and back faces.
 /// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMesh(
     const MeshDescriptorBase<PXR_NS::VtVec2fArray>& desc,
     const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath(),
-    SidedMode sidedMode = SidedMode::SingleSided);
+    SidedMode sidedMode                = SidedMode::SingleSided);
 
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreatePolyline(
     const PolylineDescriptorBase<PXR_NS::VtVec3fArray>& desc);
@@ -308,15 +308,14 @@ HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildIndexedPrimvarDS(
 /// \param holeIndices Optional array of hole indices for faces with holes.
 /// \param orientation Face orientation (default: right-handed).
 /// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
-///                  Warning: DoubleSided mode may impact render performance as it disables
-///                  backface culling and renders both front and back faces.
+/// \note DoubleSided mode may impact render performance as it disables
+///       backface culling and renders both front and back faces.
 /// \return Returns the mesh topology data source handle.
 HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildMeshDS(
-    const PXR_NS::VtArray<int>& vertexCounts,
-    const PXR_NS::VtArray<int>& faceIndices,
+    const PXR_NS::VtArray<int>& vertexCounts, const PXR_NS::VtArray<int>& faceIndices,
     const PXR_NS::VtArray<int>& holeIndices = PXR_NS::VtIntArray(),
     const PXR_NS::TfToken& orientation      = PXR_NS::HdMeshTopologySchemaTokens->rightHanded,
-    SidedMode sidedMode = SidedMode::SingleSided);
+    SidedMode sidedMode                     = SidedMode::SingleSided);
 
 HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildBasisCurvesDS(
     const PXR_NS::VtArray<int>& vertexCounts, const PXR_NS::VtArray<int>& curveIndices,

--- a/include/hvt/geometry/geometry.h
+++ b/include/hvt/geometry/geometry.h
@@ -69,6 +69,13 @@
 namespace HVT_NS
 {
 
+/// Enumeration for mesh sided mode to improve readability over boolean parameters.
+enum class SidedMode
+{
+    SingleSided,  ///< Render only front faces
+    DoubleSided   ///< Render both front and back faces
+};
+
 using PrimvarDescriptors = std::vector<std::pair<PXR_NS::TfToken, PXR_NS::HdDataSourceBaseHandle>>;
 
 /// Geometry descriptor interface.
@@ -207,29 +214,57 @@ using PolylineDescriptor2d = PolylineDescriptor<PXR_NS::VtVec2fArray>;
 [[nodiscard]] HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreatePrimvars(
     const GeometryDescriptorBase<PXR_NS::VtVec3fArray>* desc);
 
-/// Geometry and material creation.
+/// \brief Creates a 3D mesh with transformation matrix.
+/// \param desc The mesh descriptor containing geometry data.
+/// \param transform The transformation matrix to apply (default: identity matrix).
+/// \param instancerId Optional instancer ID for instanced rendering.
+/// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
+///                  Warning: DoubleSided mode may impact render performance as it disables
+///                  backface culling and renders both front and back faces.
+/// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::GfMatrix4d& transform = PXR_NS::GfMatrix4d(1),
     const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath(),
-    bool doubleSided = false);
+    SidedMode sidedMode = SidedMode::SingleSided);
 
-/// Geometry and material creation.
+/// \brief Creates a 3D mesh with transformation matrix (float precision).
+/// \param desc The mesh descriptor containing geometry data.
+/// \param transform The transformation matrix to apply (default: identity matrix).
+/// \param instancerId Optional instancer ID for instanced rendering.
+/// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
+///                  Warning: DoubleSided mode may impact render performance as it disables
+///                  backface culling and renders both front and back faces.
+/// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::GfMatrix4f& transform = PXR_NS::GfMatrix4f(1),
     const PXR_NS::SdfPath& instancerId  = PXR_NS::SdfPath(),
-    bool doubleSided = false);
+    SidedMode sidedMode = SidedMode::SingleSided);
 
+/// \brief Creates a 3D mesh without transformation.
+/// \param desc The mesh descriptor containing geometry data.
+/// \param instancerId Optional instancer ID for instanced rendering.
+/// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
+///                  Warning: DoubleSided mode may impact render performance as it disables
+///                  backface culling and renders both front and back faces.
+/// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMesh(
     const MeshDescriptorBase<PXR_NS::VtVec3fArray>& desc,
     const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath(),
-    bool doubleSided = false);
+    SidedMode sidedMode = SidedMode::SingleSided);
 
+/// \brief Creates a 2D mesh without transformation.
+/// \param desc The mesh descriptor containing geometry data.
+/// \param instancerId Optional instancer ID for instanced rendering.
+/// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
+///                  Warning: DoubleSided mode may impact render performance as it disables
+///                  backface culling and renders both front and back faces.
+/// \return Returns the mesh data source handle.
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreateMesh(
     const MeshDescriptorBase<PXR_NS::VtVec2fArray>& desc,
     const PXR_NS::SdfPath& instancerId = PXR_NS::SdfPath(),
-    bool doubleSided = false);
+    SidedMode sidedMode = SidedMode::SingleSided);
 
 HVT_API extern PXR_NS::HdRetainedContainerDataSourceHandle CreatePolyline(
     const PolylineDescriptorBase<PXR_NS::VtVec3fArray>& desc);
@@ -267,12 +302,21 @@ HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildIndexedPrimvarDS(
     const PXR_NS::TfToken& role          = PXR_NS::HdPrimvarSchemaTokens->point,
     const PXR_NS::VtIntArray& indices    = PXR_NS::VtIntArray());
 
+/// \brief Builds a mesh topology data source.
+/// \param vertexCounts Array of vertex counts per face.
+/// \param faceIndices Array of face vertex indices.
+/// \param holeIndices Optional array of hole indices for faces with holes.
+/// \param orientation Face orientation (default: right-handed).
+/// \param sidedMode Specifies whether to render single-sided or double-sided mesh.
+///                  Warning: DoubleSided mode may impact render performance as it disables
+///                  backface culling and renders both front and back faces.
+/// \return Returns the mesh topology data source handle.
 HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildMeshDS(
     const PXR_NS::VtArray<int>& vertexCounts,
     const PXR_NS::VtArray<int>& faceIndices,
     const PXR_NS::VtArray<int>& holeIndices = PXR_NS::VtIntArray(),
     const PXR_NS::TfToken& orientation      = PXR_NS::HdMeshTopologySchemaTokens->rightHanded,
-    bool doubleSided = false);
+    SidedMode sidedMode = SidedMode::SingleSided);
 
 HVT_API extern PXR_NS::HdContainerDataSourceHandle BuildBasisCurvesDS(
     const PXR_NS::VtArray<int>& vertexCounts, const PXR_NS::VtArray<int>& curveIndices,

--- a/source/geometry/geometry.cpp
+++ b/source/geometry/geometry.cpp
@@ -163,7 +163,7 @@ HdContainerDataSourceHandle BuildIndexedPrimvarDS(const VtValue& value,
 
 HdContainerDataSourceHandle BuildMeshDS(const VtArray<int>& vertexCounts,
     const VtArray<int>& faceIndices, const VtArray<int>& holeIndices,
-    const TfToken& orientation, bool doubleSided)
+    const TfToken& orientation, SidedMode sidedMode)
 {
     return HdMeshSchema::Builder()
         .SetTopology(HdMeshTopologySchema::BuildRetained(
@@ -171,7 +171,7 @@ HdContainerDataSourceHandle BuildMeshDS(const VtArray<int>& vertexCounts,
             HdRetainedTypedSampledDataSource<VtIntArray>::New(faceIndices),
             HdRetainedTypedSampledDataSource<VtIntArray>::New(holeIndices),
             _TokenDs::New(orientation)))
-        .SetDoubleSided(HdRetainedTypedSampledDataSource<bool>::New(doubleSided))
+        .SetDoubleSided(HdRetainedTypedSampledDataSource<bool>::New(sidedMode == SidedMode::DoubleSided))
         .Build();
 }
 
@@ -372,7 +372,7 @@ HdRetainedContainerDataSourceHandle CreatePolylineImp(const PolylineDescriptorBa
 template <typename T, typename M>
 HdRetainedContainerDataSourceHandle CreateMeshImp(
     const MeshDescriptorBase<T>& desc, const M* transform, const SdfPath& instancerId, 
-    bool doubleSided = false)
+    SidedMode sidedMode = SidedMode::SingleSided)
 {
     // Create the topology.
     HdDataSourceBaseHandle meshesDS = BuildMeshDS(
@@ -380,7 +380,7 @@ HdRetainedContainerDataSourceHandle CreateMeshImp(
         desc.getIndices(),
         pxr::VtIntArray(),
         HdMeshTopologySchemaTokens->rightHanded,
-        doubleSided);
+        sidedMode);
     std::vector<TfToken> primvarNames;
     std::vector<HdDataSourceBaseHandle> primvarDataSources;
     HdDataSourceBaseHandle displayStyle;
@@ -472,28 +472,28 @@ HdRetainedContainerDataSourceHandle CreatePrimvars(const GeometryDescriptorBase<
 
 HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<VtVec3fArray>& desc, const GfMatrix4d& transform,
-    const SdfPath& instancerId, bool doubleSided)
+    const SdfPath& instancerId, SidedMode sidedMode)
 {
-    return CreateMeshImp(desc, &transform, instancerId, doubleSided);
+    return CreateMeshImp(desc, &transform, instancerId, sidedMode);
 }
 
 HdRetainedContainerDataSourceHandle CreateMeshWithTransform(
     const MeshDescriptorBase<VtVec3fArray>& desc, const GfMatrix4f& transform,
-    const SdfPath& instancerId, bool doubleSided)
+    const SdfPath& instancerId, SidedMode sidedMode)
 {
-    return CreateMeshImp(desc, &transform, instancerId, doubleSided);
+    return CreateMeshImp(desc, &transform, instancerId, sidedMode);
 }
 
 HdRetainedContainerDataSourceHandle CreateMesh(
-    const MeshDescriptorBase<VtVec2fArray>& desc, const SdfPath& instancerId, bool doubleSided)
+    const MeshDescriptorBase<VtVec2fArray>& desc, const SdfPath& instancerId, SidedMode sidedMode)
 {
-    return CreateMeshImp(desc, static_cast<GfMatrix4f*>(nullptr), instancerId, doubleSided);
+    return CreateMeshImp(desc, static_cast<GfMatrix4f*>(nullptr), instancerId, sidedMode);
 }
 
 HdRetainedContainerDataSourceHandle CreateMesh(
-    const MeshDescriptorBase<VtVec3fArray>& desc, const SdfPath& instancerId, bool doubleSided)
+    const MeshDescriptorBase<VtVec3fArray>& desc, const SdfPath& instancerId, SidedMode sidedMode)
 {
-    return CreateMeshImp(desc, static_cast<GfMatrix4f*>(nullptr), instancerId, doubleSided);
+    return CreateMeshImp(desc, static_cast<GfMatrix4f*>(nullptr), instancerId, sidedMode);
 }
 
 HdRetainedContainerDataSourceHandle CreatePolyline(const PolylineDescriptorBase<VtVec2fArray>& desc)

--- a/source/geometry/geometry.cpp
+++ b/source/geometry/geometry.cpp
@@ -51,9 +51,9 @@
 #include <pxr/usd/sdr/registry.h>
 
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #elif defined(_MSC_VER)
-#pragma warning(pop)
+    #pragma warning(pop)
 #endif
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -162,8 +162,8 @@ HdContainerDataSourceHandle BuildIndexedPrimvarDS(const VtValue& value,
 }
 
 HdContainerDataSourceHandle BuildMeshDS(const VtArray<int>& vertexCounts,
-    const VtArray<int>& faceIndices, const VtArray<int>& holeIndices,
-    const TfToken& orientation, SidedMode sidedMode)
+    const VtArray<int>& faceIndices, const VtArray<int>& holeIndices, const TfToken& orientation,
+    SidedMode sidedMode)
 {
     return HdMeshSchema::Builder()
         .SetTopology(HdMeshTopologySchema::BuildRetained(
@@ -171,7 +171,8 @@ HdContainerDataSourceHandle BuildMeshDS(const VtArray<int>& vertexCounts,
             HdRetainedTypedSampledDataSource<VtIntArray>::New(faceIndices),
             HdRetainedTypedSampledDataSource<VtIntArray>::New(holeIndices),
             _TokenDs::New(orientation)))
-        .SetDoubleSided(HdRetainedTypedSampledDataSource<bool>::New(sidedMode == SidedMode::DoubleSided))
+        .SetDoubleSided(
+            HdRetainedTypedSampledDataSource<bool>::New(sidedMode == SidedMode::DoubleSided))
         .Build();
 }
 
@@ -370,17 +371,12 @@ HdRetainedContainerDataSourceHandle CreatePolylineImp(const PolylineDescriptorBa
 }
 
 template <typename T, typename M>
-HdRetainedContainerDataSourceHandle CreateMeshImp(
-    const MeshDescriptorBase<T>& desc, const M* transform, const SdfPath& instancerId, 
-    SidedMode sidedMode = SidedMode::SingleSided)
+HdRetainedContainerDataSourceHandle CreateMeshImp(const MeshDescriptorBase<T>& desc,
+    const M* transform, const SdfPath& instancerId, SidedMode sidedMode = SidedMode::SingleSided)
 {
     // Create the topology.
-    HdDataSourceBaseHandle meshesDS = BuildMeshDS(
-        desc.getVertexCounts(),
-        desc.getIndices(),
-        pxr::VtIntArray(),
-        HdMeshTopologySchemaTokens->rightHanded,
-        sidedMode);
+    HdDataSourceBaseHandle meshesDS = BuildMeshDS(desc.getVertexCounts(), desc.getIndices(),
+        pxr::VtIntArray(), HdMeshTopologySchemaTokens->rightHanded, sidedMode);
     std::vector<TfToken> primvarNames;
     std::vector<HdDataSourceBaseHandle> primvarDataSources;
     HdDataSourceBaseHandle displayStyle;


### PR DESCRIPTION
- Add doubleSided parameter to CreateMesh and CreateMeshWithTransform APIs
- Maintain backward compatibility with default false values
- This enables proper double-sided mesh rendering