### PR TITLE
OGSMOD-7899: Add up axis to model info

### DIFF
--- a/include/hvt/engine/framePass.h
+++ b/include/hvt/engine/framePass.h
@@ -69,6 +69,9 @@ struct HVT_API ModelParams
 
     /// Stores the world extent of the model.
     PXR_NS::GfRange3d worldExtent;
+    
+    /// Stores the up axis of the model.
+    bool isZAxisUp { false };
 };
 
 /// Input parameters for a render pipeline update.


### PR DESCRIPTION
Need to expose this info in a frame pass.
Please advice if there is any better choice.