### PR TITLE
Fixing issue copying AOV input information multiple times without clearing 

### DIFF
--- a/source/engine/renderBufferManager.cpp
+++ b/source/engine/renderBufferManager.cpp
@@ -262,6 +262,7 @@ bool RenderBufferManager::Impl::SetRenderOutputs(const TfTokenVector& outputs,
 
     if (inputs.size() > 0)
     {
+        _aovInputs.clear();
         std::copy(inputs.begin(), inputs.end(), back_inserter(_aovInputs));
         _viewportAov = TfToken();
     }


### PR DESCRIPTION
Description: 

This PR fixes two bugs identified in AGP sandbox:
(1) Open AGPSandbox -> UI display -> Selection Highlight -> Outline ----> crash
(2) Open AGPSandbox -> Visualize AOV -> choose Ambient Occlusion -> choose Depth -> choose Color ----> crash

After investigation this commit in components was when started the issue [here](https://git.autodesk.com/GFX/Components/commit/5551eee628e486e9701eae397fb84dad4cbcc682)

Which links to a change in HVT

Adding clear aovBuffer to avoid the copy of input aovs multiple times