### PR TITLE
OGSMOD-7969: Fix Frame Pass Depth Clear Flag

### DIFF
--- a/source/engine/framePass.cpp
+++ b/source/engine/framePass.cpp
@@ -341,34 +341,12 @@ HdTaskSharedPtrVector FramePass::GetRenderTasks(RenderBufferBindings const& inpu
     _lightingManager->SetLighting(_passParams.viewInfo.lights, _passParams.viewInfo.material,
         _passParams.viewInfo.ambient, _cameraDelegate.get(), _passParams.modelInfo.worldExtent);
 
-    // If clearBackgroundColor is false we assume we are rendering to an aov that is already initialized
-    // by a previous pass.  Skip the descriptor setup if that is the case.
-    if (_passParams.visualizeAOV == HdAovTokens->color)
-    {
-        if (_passParams.clearBackgroundColor)
-        {
-            _bufferManager->SetRenderOutputClearColor(
-                HdAovTokens->color, VtValue(_passParams.backgroundColor));
-        }
-        else
-        {
-            _bufferManager->SetRenderOutputClearColor(HdAovTokens->color, VtValue());
-        }
-    }
-
-    if (_passParams.visualizeAOV == HdAovTokens->depth)
-    {
-        if (_passParams.clearBackgroundDepth)
-        {
-            _bufferManager->SetRenderOutputClearColor(
-                HdAovTokens->depth, VtValue(_passParams.backgroundDepth));
-        }
-        else
-        {
-            _bufferManager->SetRenderOutputClearColor(HdAovTokens->depth, VtValue());
-        }
-    }
-
+    // Setup the clear parameters for color and depth. Empty VtValue() disables clearing the buffer.
+    _bufferManager->SetRenderOutputClearColor(HdAovTokens->color,
+        _passParams.clearBackgroundColor ? VtValue(_passParams.backgroundColor) : VtValue());
+    _bufferManager->SetRenderOutputClearColor(HdAovTokens->depth,
+        _passParams.clearBackgroundDepth ? VtValue(_passParams.backgroundDepth) : VtValue());
+    
     _selectionHelper->GetSettings().enableSelection = _passParams.enableSelection;
     _selectionHelper->GetSettings().enableOutline   = _passParams.enableOutline;
     _selectionHelper->GetSettings().selectionColor  = _passParams.selectionColor;

--- a/source/engine/renderBufferManager.cpp
+++ b/source/engine/renderBufferManager.cpp
@@ -144,9 +144,6 @@ private:
         HdRenderBuffer* depthBuffer, PXR_NS::HdRenderBuffer* neyeBuffer,
         const SdfPath& controllerId);
 
-    /// Resets the clear values
-    void ResetRenderOutputClear();
-
     /// The render texture dimensions.
     GfVec2i _renderBufferSize;
 
@@ -221,11 +218,6 @@ SdfPath RenderBufferManager::Impl::GetAovPath(const SdfPath& controllerID, const
     return controllerID.AppendChild(TfToken(identifier));
 }
 
-void RenderBufferManager::Impl::ResetRenderOutputClear()
-{
-    _aovTaskCache.outputClearValues.clear();
-}
-
 bool RenderBufferManager::Impl::SetRenderOutputs(const TfTokenVector& outputs,
     RenderBufferBindings const& inputs, GfVec4d const& viewport, SdfPath const& controllerId)
 {
@@ -250,9 +242,6 @@ bool RenderBufferManager::Impl::SetRenderOutputs(const TfTokenVector& outputs,
             return false;
         }
     }
-
-    // Clear the AOV task cache to be able to change the clear background and depth values.
-    ResetRenderOutputClear();
 
     // If progressive rendering is enabled, render buffer clear is only required when `_aovOutputs
     // != outputs`.


### PR DESCRIPTION
OGSMOD-7969 Fix FramePass Depth Clear Flag implementation

The render buffer clear flag was ignored, unless the render buffer was visualized.
This logic was wrong, as it is totally acceptable to control whether or not the depth or color buffer are cleared without having to visualize them. This is especially important for the depth buffer, which is typically NOT visualized.

The clear logic was also simplified by removing the call to ResetRenderOutputClear() from RenderBufferManager::Impl::SetRenderOutputs(). This was the old way to clear the render buffers and this function is no more necessary, since RenderBufferManager::SetRenderOutputClearColor() can now be called with an empty VtValue instead, which will yield the same result and reset the clear value for a given AOV name. Furthermore, it is preferable to set the clear value outside of RenderBufferManager::Impl::SetRenderOutputs(), which already contains too much complexity, and which would also early out in some cases, also failing to clear the render outputs. For these reasons, ResetRenderOutputClear() was removed.

The unit test weren't updated since there are already 2 good test cases for clearing the depth:
- TestViewportToolbox.TestFramePasses_ClearDepthBuffer
- TestViewportToolbox.TestFramePasses_ClearColorBuffer

The only reason why the depth clear bug wasn't catched by these tests is because they are configured to visualize the same AOV as the one they are testing the clear for. This makes sense for the purpose of the unit tests, I don't want to change them nor do I want to bloat our unit tests with a slight variantion of these 2 existing tests.
