### PR TITLE
OGSMOD-6304 - Fix the axis draw order by adding a small offset to the Y & Z axes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(ENABLE_TESTS "Enable tests" ON)
 option(HVT_RELEASE_ONLY_VCPKG_DEPS "Use a release-optimized vcpkg base triplet" OFF)
 
 # Add the path to the CMake helpers and import them.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Try to import from the environment variable only if OPENUSD_INSTALL_PATH isn’t already set
 if(NOT DEFINED OPENUSD_INSTALL_PATH AND DEFINED ENV{OPENUSD_INSTALL_PATH})
@@ -31,8 +31,8 @@ if(NOT DEFINED OPENUSD_INSTALL_PATH AND DEFINED ENV{OPENUSD_INSTALL_PATH})
     set(OPENUSD_INSTALL_PATH "$ENV{OPENUSD_INSTALL_PATH}" CACHE PATH "Path to local USD install")
 endif()
 
-# Includes various helpers.
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Helpers.cmake")
+# Includes various hvt helpers.
+include(Helpers)
 
 # Setups and runs vcpkg.
 include(VcpkgSetup)


### PR DESCRIPTION
The pull request changes the USD file of the tripod axes to avoid the z-depth fighting issue (which was adding instability to the unit tests). The Y and Z axes are now translated a little bit.