### PR TITLE
Disable failing tests on Android montreal

### DIFF
--- a/test/howTos/howTo04_CreateACustomRenderTask.cpp
+++ b/test/howTos/howTo04_CreateACustomRenderTask.cpp
@@ -26,9 +26,9 @@
 //
 // How to create a custom render task?
 //
-// TODO: The result image is not stable between runs on macOS, so this test is temporarily not
-// executed on that platform.
-#if defined(__APPLE__)
+// TODO: The result image is not stable between runs on macOS, skip on that platform for now
+// Disabled for Android due to baseline inconsistancy between runners. Refer to OGSMOD-8067
+#if defined(__APPLE__) || defined(__ANDROID__)
 TEST(howTo, DISABLED_createACustomRenderTask)
 #else
 TEST(howTo, createACustomRenderTask)

--- a/test/tests/testComposeTask.cpp
+++ b/test/tests/testComposeTask.cpp
@@ -248,7 +248,8 @@ TEST(TestViewportToolbox, compose_ShareTextures)
 // desktop platforms.
 
 // Disabled for iOS as the result is not stable. Refer to OGSMOD-7344
-#if TARGET_OS_IPHONE == 1
+// Disabled for Android due to baseline inconsistancy between runners. Refer to OGSMOD-8067
+#if TARGET_OS_IPHONE == 1 || defined(__ANDROID__)
 TEST(TestViewportToolbox, DISABLED_compose_ComposeTask2)
 #else
 TEST(TestViewportToolbox, compose_ComposeTask2)
@@ -336,7 +337,8 @@ TEST(TestViewportToolbox, compose_ComposeTask2)
 }
 
 // Disabled for iOS as the result is not stable. Refer to OGSMOD-7344
-#if TARGET_OS_IPHONE == 1
+// Disabled for Android due to baseline inconsistancy between runners. Refer to OGSMOD-8067
+#if TARGET_OS_IPHONE == 1 || defined(__ANDROID__)
 TEST(TestViewportToolbox, DISABLED_compose_ComposeTask3)
 #else
 TEST(TestViewportToolbox, compose_ComposeTask3)


### PR DESCRIPTION
Three tests in HVT are failing only on android machine connected in Montreal They differ from expected results for unkown reasons They block duplication of Android builder