### PR TITLE
OGSMOD-6769: Run Vulkan unit tests after OpenGL for Viewport Toolbox

### DIFF
--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -52,9 +52,9 @@ namespace TestHelpers
         std::string paramName;
     };
 
-    inline bool gRunVulkanTests = false;
-    inline bool gParameterizedTests = false;
-    inline TestNames gTestNames = TestNames {};
+    static bool gRunVulkanTests = false;
+    static bool gParameterizedTests = false;
+    static TestNames gTestNames = TestNames {};
 
     inline TestNames getTestNames(const ::testing::TestInfo* testInfo)
     {

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -31,7 +31,6 @@
     TEST_P(TestName, TestName)                                                                   \
     {                                                                                            \
         TestHelpers::gRunVulkanTests     = (GetParam() == "Vulkan");                             \
-        TestHelpers::gParameterizedTests = true;                                                 \
         TestHelpers::gTestNames          = TestHelpers::getTestNames(                            \
             ::testing::UnitTest::GetInstance()->current_test_info());                            \
         const std::string imageFile = TestHelpers::gTestNames.suiteName +                        \
@@ -53,7 +52,6 @@ namespace TestHelpers
     };
 
     inline bool gRunVulkanTests = false;
-    inline bool gParameterizedTests = false;
     inline TestNames gTestNames = TestNames {};
 
     inline TestNames getTestNames(const ::testing::TestInfo* testInfo)
@@ -64,28 +62,17 @@ namespace TestHelpers
             std::string testSuiteName = testInfo->test_suite_name();
             std::string testName      = testInfo->name();
 
-            // If parameterized tests are used, test_suite_name and name returns
-            // SuiteName/TestName/Param. Hence the following filtering is
-            // needed.
-            if (TestHelpers::gParameterizedTests)
+            size_t pos = testSuiteName.find('/');
+            if (pos != std::string::npos)
             {
-                size_t pos = testSuiteName.find('/');
-                if (pos != std::string::npos)
-                {
-                    testNames.suiteName   = testSuiteName.substr(0, pos);
-                    testNames.fixtureName = testSuiteName.substr(pos + 1);
-                }
-
-                pos = testName.find('/');
-                if (pos != std::string::npos)
-                {
-                    testNames.paramName = testName.substr(pos + 1);
-                }
+                testNames.suiteName   = testSuiteName.substr(0, pos);
+                testNames.fixtureName = testSuiteName.substr(pos + 1);
             }
-            else // Otherwise the following is enough
+
+            pos = testName.find('/');
+            if (pos != std::string::npos)
             {
-                testNames.suiteName   = testInfo->test_suite_name();
-                testNames.fixtureName = testInfo->name();
+                testNames.paramName = testName.substr(pos + 1);
             }
         }
         return testNames;

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -12,55 +12,36 @@
 #include <gtest/gtest.h>
 #include <string>
 
-#define HVT_TEST_DEFAULT_BACKEND(TestSuiteName, TestName)                                          \
-    void HVTTestDefaultBackend##TestName();                                                        \
-    TEST(TestSuiteName, TestName)                                                                  \
-    {                                                                                              \
-        TestHelpers::gParameterizedTests = false;                                                  \
-        TestHelpers::gTestNames =                                                                  \
-            TestHelpers::getTestNames(::testing::UnitTest::GetInstance()->current_test_info());    \
-        HVTTestDefaultBackend##TestName();                                                         \
-    }                                                                                              \
-    void HVTTestDefaultBackend##TestName()
-
-#if defined(ENABLE_VULKAN) && defined(WIN32)
-
-    #define HVT_TEST(TestSuiteName, TestName)                                                        \
-        std::string ParamTestName##TestName(const testing::TestParamInfo<std::string>& info)         \
-        {                                                                                            \
-            return info.param;                                                                       \
-        }                                                                                            \
-        class TestName : public ::testing::TestWithParam<std::string>                                \
-        {                                                                                            \
-        public:                                                                                      \
-            void HVTTest##TestName(                                                                  \
-                [[maybe_unused]] const std::string& computedImageName,                               \
-                [[maybe_unused]] const std::string& imageFile);                                      \
-        };                                                                                           \
-        /* TODO: Enable "Vulkan" backend when Vulkan support is complete and stable.                 \
-                   Currently, only "OpenGL" is enabled for testing. */                               \
-        INSTANTIATE_TEST_SUITE_P(TestSuiteName, TestName, ::testing::Values(/*"Vulkan",*/ "OpenGL"), \
-            ParamTestName##TestName);                                                                \
-        TEST_P(TestName, TestName)                                                                   \
-        {                                                                                            \
-            TestHelpers::gRunVulkanTests     = (GetParam() == "Vulkan");                             \
-            TestHelpers::gParameterizedTests = true;                                                 \
-            TestHelpers::gTestNames          = TestHelpers::getTestNames(                            \
-                ::testing::UnitTest::GetInstance()->current_test_info());                            \
-            const std::string imageFile = TestHelpers::gTestNames.suiteName +                        \
-                std::string("/") + TestHelpers::gTestNames.fixtureName;                              \
-            const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);    \
-            HVTTest##TestName(computedImageName, imageFile);                                         \
-        }                                                                                            \
-        void TestName::HVTTest##TestName(                                                            \
-            [[maybe_unused]] const std::string& computedImageName,                                   \
-            [[maybe_unused]] const std::string& imageFile)
-
-#else
-
-    #define HVT_TEST(TestSuiteName, TestName) HVT_TEST_DEFAULT_BACKEND(TestSuiteName, TestName)
-
-#endif
+#define HVT_TEST(TestSuiteName, TestName)                                                        \
+    std::string ParamTestName##TestName(const testing::TestParamInfo<std::string>& info)         \
+    {                                                                                            \
+        return info.param;                                                                       \
+    }                                                                                            \
+    class TestName : public ::testing::TestWithParam<std::string>                                \
+    {                                                                                            \
+    public:                                                                                      \
+        void HVTTest##TestName(                                                                  \
+            [[maybe_unused]] const std::string& computedImageName,                               \
+            [[maybe_unused]] const std::string& imageFile);                                      \
+    };                                                                                           \
+    /* TODO: Enable "Vulkan" backend when Vulkan support is complete and stable.                 \
+                Currently, only "OpenGL" is enabled for testing. */                              \
+    INSTANTIATE_TEST_SUITE_P(TestSuiteName, TestName, ::testing::Values(/*"Vulkan",*/ "OpenGL"), \
+        ParamTestName##TestName);                                                                \
+    TEST_P(TestName, TestName)                                                                   \
+    {                                                                                            \
+        TestHelpers::gRunVulkanTests     = (GetParam() == "Vulkan");                             \
+        TestHelpers::gParameterizedTests = true;                                                 \
+        TestHelpers::gTestNames          = TestHelpers::getTestNames(                            \
+            ::testing::UnitTest::GetInstance()->current_test_info());                            \
+        const std::string imageFile = TestHelpers::gTestNames.suiteName +                        \
+            std::string("/") + TestHelpers::gTestNames.fixtureName;                              \
+        const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);    \
+        HVTTest##TestName(computedImageName, imageFile);                                         \
+    }                                                                                            \
+    void TestName::HVTTest##TestName(                                                            \
+        [[maybe_unused]] const std::string& computedImageName,                                   \
+        [[maybe_unused]] const std::string& imageFile)
 
 namespace TestHelpers
 {

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -33,7 +33,9 @@
         class TestName : public ::testing::TestWithParam<std::string>                                \
         {                                                                                            \
         public:                                                                                      \
-            void HVTTest##TestName();                                                                \
+            void HVTTest##TestName(                                                                  \
+                [[maybe_unused]] const std::string& computedImageName,                               \
+                [[maybe_unused]] const std::string& imageFile);                                      \
         };                                                                                           \
         /* TODO: Enable "Vulkan" backend when Vulkan support is complete and stable.                 \
                    Currently, only "OpenGL" is enabled for testing. */                               \
@@ -45,9 +47,14 @@
             TestHelpers::gParameterizedTests = true;                                                 \
             TestHelpers::gTestNames          = TestHelpers::getTestNames(                            \
                 ::testing::UnitTest::GetInstance()->current_test_info());                            \
-            HVTTest##TestName();                                                                     \
+            const std::string imageFile = TestHelpers::gTestNames.suiteName +                        \
+                std::string("/") + TestHelpers::gTestNames.fixtureName;                              \
+            const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);    \
+            HVTTest##TestName(computedImageName, imageFile);                                         \
         }                                                                                            \
-        void TestName::HVTTest##TestName()
+        void TestName::HVTTest##TestName(                                                            \
+            [[maybe_unused]] const std::string& computedImageName,                                   \
+            [[maybe_unused]] const std::string& imageFile)
 
 #else
 

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -46,8 +46,11 @@ namespace TestHelpers
 {
     struct TestNames
     {
+        /// @brief The name of the test suite extracted from the test information
         std::string suiteName;
+        /// @brief The name of the test fixture extracted from the test suite name
         std::string fixtureName;
+        /// @brief The parameter name extracted from the test name for parameterized tests
         std::string paramName;
     };
 

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -30,8 +30,8 @@
         ParamTestName##TestName);                                                                \
     TEST_P(TestName, TestName)                                                                   \
     {                                                                                            \
-        TestHelpers::gRunVulkanTests     = (GetParam() == "Vulkan");                             \
-        TestHelpers::gTestNames          = TestHelpers::getTestNames(                            \
+        TestHelpers::gRunVulkanTests = (GetParam() == "Vulkan");                                 \
+        TestHelpers::gTestNames      = TestHelpers::getTestNames(                                \
             ::testing::UnitTest::GetInstance()->current_test_info());                            \
         const std::string imageFile = TestHelpers::gTestNames.suiteName +                        \
             std::string("/") + TestHelpers::gTestNames.fixtureName;                              \

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -9,7 +9,111 @@
 //
 #pragma once
 
+#include <gtest/gtest.h>
+#include <string>
+
+#define HVT_TEST_DEFAULT_BACKEND(TestSuiteName, TestName)                                          \
+    void HVTTestDefaultBackend##TestName();                                                        \
+    TEST(TestSuiteName, TestName)                                                                  \
+    {                                                                                              \
+        TestHelpers::gParameterizedTests = false;                                                  \
+        TestHelpers::gTestNames =                                                                  \
+            TestHelpers::getTestNames(::testing::UnitTest::GetInstance()->current_test_info());    \
+        HVTTestDefaultBackend##TestName();                                                         \
+    }                                                                                              \
+    void HVTTestDefaultBackend##TestName()
+
+#if defined(ENABLE_VULKAN) && defined(WIN32)
+
+    #define HVT_TEST(TestSuiteName, TestName)                                                        \
+        std::string ParamTestName##TestName(const testing::TestParamInfo<std::string>& info)         \
+        {                                                                                            \
+            return info.param;                                                                       \
+        }                                                                                            \
+        class TestName : public ::testing::TestWithParam<std::string>                                \
+        {                                                                                            \
+        public:                                                                                      \
+            void HVTTest##TestName();                                                                \
+        };                                                                                           \
+        /* TODO: Enable "Vulkan" backend when Vulkan support is complete and stable.                 \
+                   Currently, only "OpenGL" is enabled for testing. */                               \
+        INSTANTIATE_TEST_SUITE_P(TestSuiteName, TestName, ::testing::Values(/*"Vulkan",*/ "OpenGL"), \
+            ParamTestName##TestName);                                                                \
+        TEST_P(TestName, TestName)                                                                   \
+        {                                                                                            \
+            TestHelpers::gRunVulkanTests     = (GetParam() == "Vulkan");                             \
+            TestHelpers::gParameterizedTests = true;                                                 \
+            TestHelpers::gTestNames          = TestHelpers::getTestNames(                            \
+                ::testing::UnitTest::GetInstance()->current_test_info());                            \
+            HVTTest##TestName();                                                                     \
+        }                                                                                            \
+        void TestName::HVTTest##TestName()
+
+#else
+
+    #define HVT_TEST(TestSuiteName, TestName) HVT_TEST_DEFAULT_BACKEND(TestSuiteName, TestName)
+
+#endif
+
 namespace TestHelpers
 {
-inline bool gRunVulkanTests = false;
+    struct TestNames
+    {
+        std::string suiteName;
+        std::string fixtureName;
+        std::string paramName;
+    };
+
+    inline bool gRunVulkanTests = false;
+    inline bool gParameterizedTests = false;
+    inline TestNames gTestNames = TestNames {};
+
+    inline TestNames getTestNames(const ::testing::TestInfo* testInfo)
+    {
+        TestNames testNames;
+        if (testInfo)
+        {
+            std::string testSuiteName = testInfo->test_suite_name();
+            std::string testName      = testInfo->name();
+
+            // If parameterized tests are used, test_suite_name and name returns
+            // SuiteName/TestName/Param. Hence the following filtering is
+            // needed.
+            if (TestHelpers::gParameterizedTests)
+            {
+                size_t pos = testSuiteName.find('/');
+                if (pos != std::string::npos)
+                {
+                    testNames.suiteName   = testSuiteName.substr(0, pos);
+                    testNames.fixtureName = testSuiteName.substr(pos + 1);
+                }
+
+                pos = testName.find('/');
+                if (pos != std::string::npos)
+                {
+                    testNames.paramName = testName.substr(pos + 1);
+                }
+            }
+            else // Otherwise the following is enough
+            {
+                testNames.suiteName   = testInfo->test_suite_name();
+                testNames.fixtureName = testInfo->name();
+            }
+        }
+        return testNames;
+    }
+
+    /// Gets the image file based on the test parameter.
+    inline std::string getComputedImagePath()
+    {
+        return gTestNames.paramName.empty() ? gTestNames.fixtureName
+                                            : (gTestNames.fixtureName + "_" + gTestNames.paramName);
+    }
+
+    /// Appends image file based on the test parameter.
+    inline std::string appendParamToImageFile(const std::string& fileName)
+    {
+        return gTestNames.paramName.empty() ? fileName : (fileName + "_" + gTestNames.paramName);
+    }
+
 } // namespace TestHelpers

--- a/test/RenderingFramework/TestFlags.h
+++ b/test/RenderingFramework/TestFlags.h
@@ -52,9 +52,9 @@ namespace TestHelpers
         std::string paramName;
     };
 
-    static bool gRunVulkanTests = false;
-    static bool gParameterizedTests = false;
-    static TestNames gTestNames = TestNames {};
+    inline bool gRunVulkanTests = false;
+    inline bool gParameterizedTests = false;
+    inline TestNames gTestNames = TestNames {};
 
     inline TestNames getTestNames(const ::testing::TestInfo* testInfo)
     {

--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -153,6 +153,15 @@ bool HydraRendererContext::compareImages(
     return compareImages(inFile, outFile, threshold, pixelCountThreshold);
 }
 
+bool HydraRendererContext::compareImage(const std::string& computedFilename,
+    const std::string& baselineFilename, const uint8_t threshold, const uint8_t pixelCountThreshold)
+{
+    const auto baselinePath    = getBaselineFolder();
+    const std::string baseline = getFilename(baselinePath, baselineFilename);
+    const std::string computed = getFilename(outFullpath, computedFilename + "_computed");
+    return compareImages(computed, baseline, threshold, pixelCountThreshold);
+}
+
 bool HydraRendererContext::compareOutputImages(const std::string& fileName1,
     const std::string& fileName2, const uint8_t threshold, const uint8_t pixelCountThreshold)
 {

--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -362,13 +362,13 @@ void TestContext::run(TestHelpers::TestStage& stage, hvt::Viewport* viewport, si
     _backend->run(render, viewport->GetLastFramePass());
 }
 
-bool TestContext::validateImages(
-    const std::string& computedImageName, const std::string& imageFile, const uint8_t threshold)
+bool TestContext::validateImages(const std::string& computedImageName, const std::string& imageFile,
+    const uint8_t threshold, const uint8_t pixelCountThreshold)
 {
     if (!_backend->saveImage(computedImageName)) {
         return false;
     }
-    return _backend->compareImage(computedImageName, imageFile, threshold);
+    return _backend->compareImage(computedImageName, imageFile, threshold, pixelCountThreshold);
 }
 
 FramePassInstance FramePassInstance::CreateInstance(std::string const& rendererName,

--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -362,6 +362,15 @@ void TestContext::run(TestHelpers::TestStage& stage, hvt::Viewport* viewport, si
     _backend->run(render, viewport->GetLastFramePass());
 }
 
+bool TestContext::validateImages(
+    const std::string& computedImageName, const std::string& imageFile, const uint8_t threshold)
+{
+    if (!_backend->saveImage(computedImageName)) {
+        return false;
+    }
+    return _backend->compareImage(computedImageName, imageFile, threshold);
+}
+
 FramePassInstance FramePassInstance::CreateInstance(std::string const& rendererName,
     pxr::UsdStageRefPtr& stage, std::shared_ptr<TestHelpers::HydraRendererContext>& backend,
     std::string const& uid)

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -233,6 +233,9 @@ public:
     // Render a viewport i.e., several frame passes.
     void run(TestHelpers::TestStage& stage, hvt::Viewport* viewport, size_t frameCount);
 
+    bool validateImages(const std::string& computedImageName, const std::string& imageFile,
+        const uint8_t threshold = 1);
+
 public:
     // The GPU backend used by the unit test.
     std::shared_ptr<TestHelpers::HydraRendererContext> _backend;

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -234,7 +234,7 @@ public:
     void run(TestHelpers::TestStage& stage, hvt::Viewport* viewport, size_t frameCount);
 
     bool validateImages(const std::string& computedImageName, const std::string& imageFile,
-        const uint8_t threshold = 1);
+        const uint8_t threshold = 1, const uint8_t pixelCountThreshold = 1);
 
 public:
     // The GPU backend used by the unit test.

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -122,6 +122,12 @@ public:
     virtual bool compareImages(const std::string& fileName, const uint8_t threshold = 1,
         const uint8_t pixelCountThreshold = 0);
 
+    /// Compare image against stored "_computed" image and throws if a difference is found within
+    /// the threshold defined.
+    virtual bool compareImage(const std::string& computedFilename,
+        const std::string& baselineFilename, const uint8_t threshold = 1,
+        const uint8_t pixelCountThreshold = 1);
+
     /// Compare two "_computed" images and throws if a difference is found within the thresholds
     /// defined
     virtual bool compareOutputImages(const std::string& fileName1, const std::string& fileName2,

--- a/test/howTos/howTo01_CreateHgiImplementation.cpp
+++ b/test/howTos/howTo01_CreateHgiImplementation.cpp
@@ -52,7 +52,7 @@
 //
 // How to create an Hgi implementation?
 //
-TEST(howTo, createHgiImplementation)
+HVT_TEST(howTo, CreateHgiImplementation)
 {
     pxr::HgiUniquePtr hgi;
     pxr::HdDriver hgiDriver;

--- a/test/howTos/howTo02_CreateOneFramePass.cpp
+++ b/test/howTos/howTo02_CreateOneFramePass.cpp
@@ -99,12 +99,5 @@ HVT_TEST(howTo, createOneFramePass)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo02_CreateOneFramePass.cpp
+++ b/test/howTos/howTo02_CreateOneFramePass.cpp
@@ -22,10 +22,12 @@
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to create one frame pass using Storm?
 //
-TEST(howTo, createOneFramePass)
+HVT_TEST(howTo, createOneFramePass)
 {
     // Helper to create the Hgi implementation.
 
@@ -97,10 +99,12 @@ TEST(howTo, createOneFramePass)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo03_CreateTwoFramePasses.cpp
+++ b/test/howTos/howTo03_CreateTwoFramePasses.cpp
@@ -202,12 +202,5 @@ HVT_TEST(howTo, DISABLED_createTwoFramePasses)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile, 1));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo03_CreateTwoFramePasses.cpp
+++ b/test/howTos/howTo03_CreateTwoFramePasses.cpp
@@ -25,6 +25,8 @@
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to create two frame passes?
 //
@@ -35,9 +37,9 @@
 // NOTE: It turns out "axisTripod.usda" has coplanar geometry and it can create random
 //       inconsistencies on all platforms. Refer to OGSMOD-6304.
 #if (TARGET_OS_IPHONE == 1) || (defined(_WIN32) && defined(ENABLE_VULKAN)) || defined(__linux__) || !defined(ADSK_OPENUSD_PENDING)
-TEST(howTo, DISABLED_createTwoFramePasses)
+HVT_TEST(howTo, DISABLED_createTwoFramePasses)
 #else
-TEST(howTo, DISABLED_createTwoFramePasses)
+HVT_TEST(howTo, DISABLED_createTwoFramePasses)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -200,9 +202,12 @@ TEST(howTo, DISABLED_createTwoFramePasses)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile, 1));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
+
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile, 1));
 }

--- a/test/howTos/howTo04_CreateACustomRenderTask.cpp
+++ b/test/howTos/howTo04_CreateACustomRenderTask.cpp
@@ -23,15 +23,17 @@
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to create a custom render task?
 //
 // TODO: The result image is not stable between runs on macOS, skip on that platform for now
 // Disabled for Android due to baseline inconsistancy between runners. Refer to OGSMOD-8067
 #if defined(__APPLE__) || defined(__ANDROID__)
-TEST(howTo, DISABLED_createACustomRenderTask)
+HVT_TEST(howTo, DISABLED_createACustomRenderTask)
 #else
-TEST(howTo, createACustomRenderTask)
+HVT_TEST(howTo, createACustomRenderTask)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -137,10 +139,12 @@ TEST(howTo, createACustomRenderTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo04_CreateACustomRenderTask.cpp
+++ b/test/howTos/howTo04_CreateACustomRenderTask.cpp
@@ -29,7 +29,7 @@
 // How to create a custom render task?
 //
 // TODO: The result image is not stable between runs on macOS, skip on that platform for now
-// Disabled for Android due to baseline inconsistancy between runners. Refer to OGSMOD-8067
+// Disabled for Android due to baseline inconsistency between runners. Refer to OGSMOD-8067
 #if defined(__APPLE__) || defined(__ANDROID__)
 HVT_TEST(howTo, DISABLED_createACustomRenderTask)
 #else
@@ -139,12 +139,5 @@ HVT_TEST(howTo, createACustomRenderTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo05_UseSSAORenderTask.cpp
+++ b/test/howTos/howTo05_UseSSAORenderTask.cpp
@@ -26,15 +26,17 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to use the SSAO render task?
 //
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
 // Note: As Android is now built on macOS platform, the same challenge exists!
 #if defined(__APPLE__) || defined(__ANDROID__)
-TEST(howTo, DISABLED_useSSAORenderTask)
+HVT_TEST(howTo, DISABLED_useSSAORenderTask)
 #else
-TEST(howTo, useSSAORenderTask)
+HVT_TEST(howTo, useSSAORenderTask)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -149,10 +151,12 @@ TEST(howTo, useSSAORenderTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo05_UseSSAORenderTask.cpp
+++ b/test/howTos/howTo05_UseSSAORenderTask.cpp
@@ -151,12 +151,5 @@ HVT_TEST(howTo, useSSAORenderTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo06_UseFXAARenderTask.cpp
+++ b/test/howTos/howTo06_UseFXAARenderTask.cpp
@@ -26,14 +26,16 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to use the FXAA render task?
 //
 // FIXME: OGSMOD-7891 - Produce weird image & unstable images between runs on Android.
 #if defined(__APPLE__) || defined(__ANDROID__)
-TEST(howTo, DISABLED_useFXAARenderTask)
+HVT_TEST(howTo, DISABLED_useFXAARenderTask)
 #else
-TEST(howTo, useFXAARenderTask)
+HVT_TEST(howTo, useFXAARenderTask)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -134,10 +136,12 @@ TEST(howTo, useFXAARenderTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo06_UseFXAARenderTask.cpp
+++ b/test/howTos/howTo06_UseFXAARenderTask.cpp
@@ -136,12 +136,5 @@ HVT_TEST(howTo, useFXAARenderTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo07_UseIncludeExclude.cpp
+++ b/test/howTos/howTo07_UseIncludeExclude.cpp
@@ -25,6 +25,8 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // Include or exclude geometry prims on the fly?
 //
@@ -111,9 +113,9 @@ void CreateTest(const std::shared_ptr<TestHelpers::TestContext>& context,
 // FIXME: It's sometime failed to render on iOS.Refer to OGSMOD-6933.
 // Need to investigate if Android has similar issue too
 #if defined(__ANDROID__) || (TARGET_OS_IPHONE == 1)
-TEST(howTo, DISABLED_useCollectionToExclude)
+HVT_TEST(howTo, DISABLED_useCollectionToExclude)
 #else
-TEST(howTo, useCollectionToExclude)
+HVT_TEST(howTo, useCollectionToExclude)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -134,20 +136,22 @@ TEST(howTo, useCollectionToExclude)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
 // FIXME: It's sometime failed to render on iOS.Refer to OGSMOD-6933.
 // Need to investigate if Android has similar issue too
 #if defined(__ANDROID__) || (TARGET_OS_IPHONE == 1)
-TEST(howTo, DISABLED_useCollectionToInclude)
+HVT_TEST(howTo, DISABLED_useCollectionToInclude)
 #else
-TEST(howTo, useCollectionToInclude)
+HVT_TEST(howTo, useCollectionToInclude)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -168,10 +172,12 @@ TEST(howTo, useCollectionToInclude)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo07_UseIncludeExclude.cpp
+++ b/test/howTos/howTo07_UseIncludeExclude.cpp
@@ -136,14 +136,7 @@ HVT_TEST(howTo, useCollectionToExclude)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }
 
 // FIXME: It's sometime failed to render on iOS.Refer to OGSMOD-6933.
@@ -172,12 +165,5 @@ HVT_TEST(howTo, useCollectionToInclude)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo08_UseBoundingBoxSceneIndex.cpp
+++ b/test/howTos/howTo08_UseBoundingBoxSceneIndex.cpp
@@ -31,13 +31,15 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
 // issues. Refer to OGSMOD-5546.
 //
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(howTo, DISABLED_useBoundingBoxSceneIndexFilter)
+HVT_TEST(howTo, DISABLED_useBoundingBoxSceneIndexFilter)
 #else
-TEST(howTo, useBoundingBoxSceneIndexFilter)
+HVT_TEST(howTo, useBoundingBoxSceneIndexFilter)
 #endif
 {
     // This unit test demonstrates how to add a scene index filter to draw a bounding box using
@@ -112,10 +114,12 @@ TEST(howTo, useBoundingBoxSceneIndexFilter)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo08_UseBoundingBoxSceneIndex.cpp
+++ b/test/howTos/howTo08_UseBoundingBoxSceneIndex.cpp
@@ -114,12 +114,5 @@ HVT_TEST(howTo, useBoundingBoxSceneIndexFilter)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo09_UseWireFrameSceneIndex.cpp
+++ b/test/howTos/howTo09_UseWireFrameSceneIndex.cpp
@@ -120,14 +120,7 @@ HVT_TEST(howTo, useWireFrameCollectionRepr)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }
 
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
@@ -217,12 +210,5 @@ HVT_TEST(howTo, useWireFrameSceneIndex)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo09_UseWireFrameSceneIndex.cpp
+++ b/test/howTos/howTo09_UseWireFrameSceneIndex.cpp
@@ -31,6 +31,8 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
 // issues. Refer to OGSMOD-5546.
 //
@@ -38,9 +40,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 // Refer to https://forum.aousd.org/t/hdstorm-mesh-wires-drawing-issue-in-usd-24-05-on-macos/1523
 //
 #if defined(__ANDROID__) || defined(__APPLE__)
-TEST(howTo, DISABLED_useWireFrameCollectionRepr)
+HVT_TEST(howTo, DISABLED_useWireFrameCollectionRepr)
 #else
-TEST(howTo, useWireFrameCollectionRepr)
+HVT_TEST(howTo, useWireFrameCollectionRepr)
 #endif
 {
     // This unit test demonstrates how display a wire frame of the model using the collection
@@ -118,12 +120,14 @@ TEST(howTo, useWireFrameCollectionRepr)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
@@ -133,9 +137,9 @@ TEST(howTo, useWireFrameCollectionRepr)
 // Refer to https://forum.aousd.org/t/hdstorm-mesh-wires-drawing-issue-in-usd-24-05-on-macos/1523
 //
 #if defined(__ANDROID__) || defined(__APPLE__)
-TEST(howTo, DISABLED_useWireFrameSceneIndex)
+HVT_TEST(howTo, DISABLED_useWireFrameSceneIndex)
 #else
-TEST(howTo, useWireFrameSceneIndex)
+HVT_TEST(howTo, useWireFrameSceneIndex)
 #endif
 {
     // This unit test demonstrates how display a wire frame of the model using a scene index
@@ -213,10 +217,12 @@ TEST(howTo, useWireFrameSceneIndex)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo10_CustomListOfTasks.cpp
+++ b/test/howTos/howTo10_CustomListOfTasks.cpp
@@ -111,14 +111,10 @@ HVT_TEST(howTo, createDefaultListOfTasks)
 
     // Validates the rendering result against normally created default list of tasks.
 
-    const std::string imageFile = 
+    const std::string imageFilename =
         TestHelpers::gTestNames.suiteName + std::string("/") + std::string("createOneFramePass");
 
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFilename));
 }
 
 //
@@ -214,14 +210,10 @@ HVT_TEST(howTo, createDefaultListOfTasks2)
 
     // Validates the rendering result against normally created default list of tasks.
 
-    const std::string imageFile = 
+    const std::string imageFilename =
         TestHelpers::gTestNames.suiteName + std::string("/") + std::string("createOneFramePass");
 
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFilename));
 }
 
 //
@@ -313,12 +305,5 @@ HVT_TEST(howTo, createMinimalListOfTasks)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/howTos/howTo10_CustomListOfTasks.cpp
+++ b/test/howTos/howTo10_CustomListOfTasks.cpp
@@ -27,10 +27,12 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to manually create the default list of tasks?
 //
-TEST(howTo, createDefaultListOfTasks)
+HVT_TEST(howTo, createDefaultListOfTasks)
 {
     auto context = TestHelpers::CreateTestContext();
 
@@ -109,18 +111,20 @@ TEST(howTo, createDefaultListOfTasks)
 
     // Validates the rendering result against normally created default list of tasks.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string("createOneFramePass");
+    const std::string imageFile = 
+        TestHelpers::gTestNames.suiteName + std::string("/") + std::string("createOneFramePass");
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
 //
 // How to manually create the default list of tasks?
 //
-TEST(howTo, createDefaultListOfTasks2)
+HVT_TEST(howTo, createDefaultListOfTasks2)
 {
     auto context = TestHelpers::CreateTestContext();
 
@@ -210,18 +214,20 @@ TEST(howTo, createDefaultListOfTasks2)
 
     // Validates the rendering result against normally created default list of tasks.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string("createOneFramePass");
+    const std::string imageFile = 
+        TestHelpers::gTestNames.suiteName + std::string("/") + std::string("createOneFramePass");
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
 //
 // How to manually create the minimal list of tasks?
 //
-TEST(howTo, createMinimalListOfTasks)
+HVT_TEST(howTo, createMinimalListOfTasks)
 {
     auto context = TestHelpers::CreateTestContext();
 
@@ -307,10 +313,12 @@ TEST(howTo, createMinimalListOfTasks)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo11_UseSkyDomeTask.cpp
+++ b/test/howTos/howTo11_UseSkyDomeTask.cpp
@@ -26,13 +26,15 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/TestFlags.h>
+
 //
 // How to use the SkyDome render task?
 //
 #if defined(__ANDROID__) || (TARGET_OS_IPHONE == 1)
-TEST(howTo, DISABLED_useSkyDomeTask)
+HVT_TEST(howTo, DISABLED_useSkyDomeTask)
 #else
-TEST(howTo, useSkyDomeTask)
+HVT_TEST(howTo, useSkyDomeTask)
 #endif
 {
     // Helper to create the Hgi implementation.
@@ -137,10 +139,12 @@ TEST(howTo, useSkyDomeTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->test_suite_name()) + std::string("/") +
-        std::string(test_info_->name());
+    const std::string imageFile =
+        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }

--- a/test/howTos/howTo11_UseSkyDomeTask.cpp
+++ b/test/howTos/howTo11_UseSkyDomeTask.cpp
@@ -139,12 +139,5 @@ HVT_TEST(howTo, useSkyDomeTask)
 
     // Validates the rendering result.
 
-    const std::string imageFile =
-        TestHelpers::gTestNames.suiteName + std::string("/") + TestHelpers::gTestNames.fixtureName;
-
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }

--- a/test/tests/testFramePass.cpp
+++ b/test/tests/testFramePass.cpp
@@ -41,7 +41,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
-TEST(TestViewportToolbox, framePassUID)
+#include <RenderingFramework/TestFlags.h>
+
+HVT_TEST(TestViewportToolbox, framePassUID)
 {
     // The unit tests the name & unique identifier using the various ways to create a frame pass
     // instance.
@@ -101,9 +103,9 @@ TEST(TestViewportToolbox, framePassUID)
 // issues. Refer to OGSMOD-5546.
 //
 #if defined(__ANDROID__) || defined(__APPLE__) || defined(__linux__)
-TEST(TestViewportToolbox, DISABLED_testFramePassColorSpace)
+HVT_TEST(TestViewportToolbox, DISABLED_testFramePassColorSpace)
 #else
-TEST(TestViewportToolbox, testFramePassColorSpace)
+HVT_TEST(TestViewportToolbox, testFramePassColorSpace)
 #endif
 {
     // The goal of the unit test is to validate the colorspace value in FramePassParams is properly
@@ -231,14 +233,15 @@ void TestDynamicFramePassParams(
 
     // Saves the rendered image and compares results.
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_testDynamicCameraAndLights)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_testDynamicCameraAndLights)
 #else
-TEST(TestViewportToolbox, testDynamicCameraAndLights)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, testDynamicCameraAndLights)
 #endif
 {
     // Use a fixed resolution (the image width/height do not change).
@@ -282,13 +285,14 @@ TEST(TestViewportToolbox, testDynamicCameraAndLights)
     };
 
     // Test the Task Controller with dynamic lighting and camera view.
-    TestDynamicFramePassParams(getRenderSize, getViewMatrix, getLights, test_info_->name());
+    TestDynamicFramePassParams(
+        getRenderSize, getViewMatrix, getLights, TestHelpers::gTestNames.fixtureName);
 }
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_testDynamicResolution)
+HVT_TEST(TestViewportToolbox, DISABLED_testDynamicResolution)
 #else
-TEST(TestViewportToolbox, testDynamicResolution)
+HVT_TEST(TestViewportToolbox, testDynamicResolution)
 #endif
 {
     // Render at half resolution for the first few frames, then change the render size to the full
@@ -314,7 +318,8 @@ TEST(TestViewportToolbox, testDynamicResolution)
         [](TestHelpers::TestStage& testStage, int) { return testStage.defaultLights(); };
 
     // Test the Task Controller with a dynamic render resolution.
-    TestDynamicFramePassParams(getRenderSize, getViewMatrix, getLights, test_info_->name());
+    TestDynamicFramePassParams(
+        getRenderSize, getViewMatrix, getLights, TestHelpers::gTestNames.fixtureName);
 }
 
 #if defined(__ANDROID__)

--- a/test/tests/testFramePass.cpp
+++ b/test/tests/testFramePass.cpp
@@ -234,14 +234,13 @@ void TestDynamicFramePassParams(
     // Saves the rendered image and compares results.
 
     const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFile));
 }
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_testDynamicCameraAndLights)
+HVT_TEST(TestViewportToolbox, DISABLED_testDynamicCameraAndLights)
 #else
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, testDynamicCameraAndLights)
+HVT_TEST(TestViewportToolbox, testDynamicCameraAndLights)
 #endif
 {
     // Use a fixed resolution (the image width/height do not change).

--- a/test/tests/testFramePasses.cpp
+++ b/test/tests/testFramePasses.cpp
@@ -100,16 +100,16 @@ HVT_TEST(TestViewportToolbox, TestFramePasses_MainOnly)
 
     // Validate the rendering result.
 
-    const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
+    const std::string computedImagePath = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->validateImages(computedImagePath, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
 // Note: As Android is now built on macOS platform, the same challenge exists!
 #if defined(__APPLE__) || defined(__ANDROID__)
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestFramePasses_MainWithBlur)
+HVT_TEST(TestViewportToolbox, DISABLED_TestFramePasses_MainWithBlur)
 #else
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestFramePasses_MainWithBlur)
+HVT_TEST(TestViewportToolbox, TestFramePasses_MainWithBlur)
 #endif
 {
     auto context = TestHelpers::CreateTestContext();
@@ -206,8 +206,8 @@ HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestFramePasses_MainWithBlur)
     // Run the render loop.
     context->run(render, _sceneFramePass.get());
 
-    const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
+    const std::string computedImagePath = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->validateImages(computedImagePath, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
@@ -316,8 +316,8 @@ HVT_TEST(TestViewportToolbox, TestFramePasses_MainWithFxaa)
     // Run the render loop.
     context->run(render, _sceneFramePass.get());
 
-    const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
+    const std::string computedImagePath = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->validateImages(computedImagePath, TestHelpers::gTestNames.fixtureName));
 }
 
 //
@@ -409,8 +409,8 @@ HVT_TEST(TestViewportToolbox, TestFramePasses_SceneIndex)
 
     // Step 6 - Validate the expected result.
 
-    const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
+    const std::string computedImagePath = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->validateImages(computedImagePath, TestHelpers::gTestNames.fixtureName));
 }
 
 // Note: The second frame pass is not displayed on Android. Refer to OGSMOD-7277.

--- a/test/tests/testFramePasses.cpp
+++ b/test/tests/testFramePasses.cpp
@@ -101,9 +101,7 @@ HVT_TEST(TestViewportToolbox, TestFramePasses_MainOnly)
     // Validate the rendering result.
 
     const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(
-        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
+    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
@@ -209,9 +207,7 @@ HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestFramePasses_MainWithBlur)
     context->run(render, _sceneFramePass.get());
 
     const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(
-        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
+    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
@@ -321,9 +317,7 @@ HVT_TEST(TestViewportToolbox, TestFramePasses_MainWithFxaa)
     context->run(render, _sceneFramePass.get());
 
     const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(
-        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
+    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 //
@@ -416,9 +410,7 @@ HVT_TEST(TestViewportToolbox, TestFramePasses_SceneIndex)
     // Step 6 - Validate the expected result.
 
     const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(
-        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
+    ASSERT_TRUE(context->validateImages(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // Note: The second frame pass is not displayed on Android. Refer to OGSMOD-7277.

--- a/test/tests/testFramePasses.cpp
+++ b/test/tests/testFramePasses.cpp
@@ -32,7 +32,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #include <gtest/gtest.h>
 
-TEST(TestViewportToolbox, TestFramePasses_MainOnly)
+HVT_TEST(TestViewportToolbox, TestFramePasses_MainOnly)
 {
     // This unit test uses a frame pass to render a USD 3D model using Storm.
 
@@ -100,18 +100,18 @@ TEST(TestViewportToolbox, TestFramePasses_MainOnly)
 
     // Validate the rendering result.
 
-    const std::string imageFile = std::string(test_info_->name());
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    const std::string computedFileName = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(
+        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
 // Note: As Android is now built on macOS platform, the same challenge exists!
 #if defined(__APPLE__) || defined(__ANDROID__)
-TEST(TestViewportToolbox, DISABLED_TestFramePasses_MainWithBlur)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestFramePasses_MainWithBlur)
 #else
-TEST(TestViewportToolbox, TestFramePasses_MainWithBlur)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestFramePasses_MainWithBlur)
 #endif
 {
     auto context = TestHelpers::CreateTestContext();
@@ -208,17 +208,18 @@ TEST(TestViewportToolbox, TestFramePasses_MainWithBlur)
     // Run the render loop.
     context->run(render, _sceneFramePass.get());
 
-    const std::string imageFile = std::string(test_info_->name());
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    const std::string computedFileName = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(
+        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: The result image is not stable between runs on macOS. Refer to OGSMOD-4820.
 // Note: As Android is now built on macOS platform, the same challenge exists!
 #if defined(__APPLE__) || defined(__ANDROID__)
-TEST(TestViewportToolbox, DISABLED_TestFramePasses_MainWithFxaa)
+HVT_TEST(TestViewportToolbox, DISABLED_TestFramePasses_MainWithFxaa)
 #else
-TEST(TestViewportToolbox, TestFramePasses_MainWithFxaa)
+HVT_TEST(TestViewportToolbox, TestFramePasses_MainWithFxaa)
 #endif
 {
     auto context = TestHelpers::CreateTestContext();
@@ -319,16 +320,16 @@ TEST(TestViewportToolbox, TestFramePasses_MainWithFxaa)
     // Run the render loop.
     context->run(render, _sceneFramePass.get());
 
-    const std::string imageFile = std::string(test_info_->name());
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    const std::string computedFileName = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(
+        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 //
 // The unit test is an example of a single frame pass using a scene index.
 //
-TEST(TestViewportToolbox, TestFramePasses_SceneIndex)
+HVT_TEST(TestViewportToolbox, TestFramePasses_SceneIndex)
 {
     auto context = TestHelpers::CreateTestContext();
 
@@ -414,9 +415,10 @@ TEST(TestViewportToolbox, TestFramePasses_SceneIndex)
 
     // Step 6 - Validate the expected result.
 
-    const std::string imageFile = std::string(test_info_->name());
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    const std::string computedFileName = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(
+        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // Note: The second frame pass is not displayed on Android. Refer to OGSMOD-7277.

--- a/test/tests/testSearches.cpp
+++ b/test/tests/testSearches.cpp
@@ -104,9 +104,9 @@ void _PrintData(
 } // namespace
 
 #if TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestSearchPrims)
+HVT_TEST(TestViewportToolbox, DISABLED_TestSearchPrims)
 #else
-TEST(TestViewportToolbox, TestSearchPrims)
+HVT_TEST(TestViewportToolbox, TestSearchPrims)
 #endif
 {
     // The unit test searches for some prims and highlights them.
@@ -169,16 +169,16 @@ TEST(TestViewportToolbox, TestSearchPrims)
 
     // Validates the rendering result.
 
-    const std::string imageFile = std::string(test_info_->name());
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    const std::string computedFileName = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(
+        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 #if TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestSearchFaces)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestSearchFaces)
 #else
-TEST(TestViewportToolbox, TestSearchFaces)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestSearchFaces)
 #endif
 {
     // The unit test searches for some faces and highlights them.
@@ -241,24 +241,24 @@ TEST(TestViewportToolbox, TestSearchFaces)
 
     // Validates the rendering result.
 
-    std::string imageFile = std::string(test_info_->name());
+    std::string computedFileName = TestHelpers::getComputedImagePath();
 
 #if PXR_VERSION <= 2505 && __APPLE__
-    imageFile = "origin_dev/02505/" + imageFile;
+    computedFileName = "origin_dev/02505/" + computedFileName;
 #endif
 
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
-
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(
+        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
 // issues. Refer to OGSMOD-5546.
 //
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestSearchEdges)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestSearchEdges)
 #else
-TEST(TestViewportToolbox, TestSearchEdges)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestSearchEdges)
 #endif
 {
     // The unit test searches for some edges.
@@ -345,18 +345,19 @@ TEST(TestViewportToolbox, TestSearchEdges)
 
     // As the edge selection should do nothing use an existing baseline image.
     const std::string imageFile = std::string("TestFramePasses_MainOnly");
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
 // issues. Refer to OGSMOD-5546.
 //
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestSearchPoints)
+HVT_TEST(TestViewportToolbox, DISABLED_TestSearchPoints)
 #else
-TEST(TestViewportToolbox, TestSearchPoints)
+HVT_TEST(TestViewportToolbox, TestSearchPoints)
 #endif
 {
     // The unit test searches for some points.
@@ -438,12 +439,14 @@ TEST(TestViewportToolbox, TestSearchPoints)
 
     // As the point selection should do nothing use an existing baseline image.
     const std::string imageFile = std::string("TestFramePasses_MainOnly");
-    ASSERT_TRUE(context->_backend->saveImage(imageFile));
+    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
 
-    ASSERT_TRUE(context->_backend->compareImages(imageFile));
+    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
+
+    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
 }
 
-TEST(TestViewportToolbox, TestSearchUsingCube)
+HVT_TEST(TestViewportToolbox, TestSearchUsingCube)
 {
     // The unit test executes all the searches on a very basic model to better check / understand
     // the content of the search results.

--- a/test/tests/testSearches.cpp
+++ b/test/tests/testSearches.cpp
@@ -438,12 +438,8 @@ HVT_TEST(TestViewportToolbox, TestSearchPoints)
     // Validates the rendering result.
 
     // As the point selection should do nothing use an existing baseline image.
-    const std::string imageFile = std::string("TestFramePasses_MainOnly");
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    const std::string imageFilename = std::string("TestFramePasses_MainOnly");
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFilename));
 }
 
 HVT_TEST(TestViewportToolbox, TestSearchUsingCube)

--- a/test/tests/testSearches.cpp
+++ b/test/tests/testSearches.cpp
@@ -169,16 +169,14 @@ HVT_TEST(TestViewportToolbox, TestSearchPrims)
 
     // Validates the rendering result.
 
-    const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(
-        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
+    const std::string computedImagePath = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(context->validateImages(computedImagePath, TestHelpers::gTestNames.fixtureName));
 }
 
 #if TARGET_OS_IPHONE == 1
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestSearchFaces)
+HVT_TEST(TestViewportToolbox, DISABLED_TestSearchFaces)
 #else
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestSearchFaces)
+HVT_TEST(TestViewportToolbox, TestSearchFaces)
 #endif
 {
     // The unit test searches for some faces and highlights them.
@@ -247,18 +245,16 @@ HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestSearchFaces)
     computedFileName = "origin_dev/02505/" + computedFileName;
 #endif
 
-    ASSERT_TRUE(context->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(
-        context->_backend->compareImage(computedFileName, TestHelpers::gTestNames.fixtureName));
+    ASSERT_TRUE(context->validateImages(computedImageName, TestHelpers::gTestNames.fixtureName));
 }
 
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix
 // issues. Refer to OGSMOD-5546.
 //
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestSearchEdges)
+HVT_TEST(TestViewportToolbox, DISABLED_TestSearchEdges)
 #else
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestSearchEdges)
+HVT_TEST(TestViewportToolbox, TestSearchEdges)
 #endif
 {
     // The unit test searches for some edges.
@@ -344,11 +340,8 @@ HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestSearchEdges)
     // Validates the rendering result.
 
     // As the edge selection should do nothing use an existing baseline image.
-    const std::string imageFile = std::string("TestFramePasses_MainOnly");
-    const std::string computedImageName = TestHelpers::appendParamToImageFile(imageFile);
-
-    ASSERT_TRUE(context->_backend->saveImage(computedImageName));
-    ASSERT_TRUE(context->_backend->compareImage(computedImageName, imageFile));
+    const std::string imageFilename = std::string("TestFramePasses_MainOnly");
+    ASSERT_TRUE(context->validateImages(computedImageName, imageFilename));
 }
 
 // FIXME: Android unit test framework does not report the error message, make it impossible to fix

--- a/test/tests/testTaskManager.cpp
+++ b/test/tests/testTaskManager.cpp
@@ -49,9 +49,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 #include <pxr/usd/sdf/path.h>
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-TEST(TestViewportToolbox, DISABLED_TestTaskManager)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestTaskManager)
 #else
-TEST(TestViewportToolbox, TestTaskManager)
+HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestTaskManager)
 #endif
 {
     // The goal of the unit test is to validate the "TaskManager" and "FramePass" classes working
@@ -179,10 +179,10 @@ TEST(TestViewportToolbox, TestTaskManager)
 
     // Validates the rendering result.
 
-    const std::string imageFile { test_info_->name() };
-    ASSERT_TRUE(testContext->_backend->saveImage(imageFile));
-
-    ASSERT_TRUE(testContext->_backend->compareImages(imageFile, 1));
+    const std::string computedFileName = TestHelpers::getComputedImagePath();
+    ASSERT_TRUE(testContext->_backend->saveImage(computedFileName));
+    ASSERT_TRUE(testContext->_backend->compareImage(
+        computedFileName, TestHelpers::gTestNames.fixtureName, 1));
 }
 
 namespace
@@ -200,7 +200,7 @@ hvt::RenderIndexProxyPtr CreateStormRenderer(std::shared_ptr<TestHelpers::TestCo
 }
 } // namespace
 
-TEST(TestViewportToolbox, TestTaskManagerAddRemove)
+HVT_TEST(TestViewportToolbox, TestTaskManagerAddRemove)
 {
     // The goal of the unit test is to validate task insertion and removal with the TaskManager.
 
@@ -240,7 +240,7 @@ TEST(TestViewportToolbox, TestTaskManagerAddRemove)
     taskManager = nullptr;
 }
 
-TEST(TestViewportToolbox, TestTaskManagerCommitFn)
+HVT_TEST(TestViewportToolbox, TestTaskManagerCommitFn)
 {
     // The goal of the unit test is to validate the "TaskManager" commit function execution, which
     // is responsible for updating HdTask parameters.
@@ -317,7 +317,7 @@ TEST(TestViewportToolbox, TestTaskManagerCommitFn)
     taskManager = nullptr;
 }
 
-TEST(TestViewportToolbox, TestTaskManagerSetTaskValue)
+HVT_TEST(TestViewportToolbox, TestTaskManagerSetTaskValue)
 {
     // The goal of the unit test is to validate TaskManager::GetTaskValue and
     // TaskManager::SetTaskValue.
@@ -385,7 +385,7 @@ TEST(TestViewportToolbox, TestTaskManagerSetTaskValue)
     taskManager = nullptr;
 }
 
-TEST(TestViewportToolbox, TestTaskManagerTaskFlags)
+HVT_TEST(TestViewportToolbox, TestTaskManagerTaskFlags)
 {
     // The goal of the unit test is to validate the task flags that are used by the Task Manager
     // to classify the tasks into categories upon creation.
@@ -482,7 +482,7 @@ TEST(TestViewportToolbox, TestTaskManagerTaskFlags)
     taskManager = nullptr;
 }
 
-TEST(TestViewportToolbox, TestTaskManagerEnableTask)
+HVT_TEST(TestViewportToolbox, TestTaskManagerEnableTask)
 {
     // The goal of the unit test is to validate TaskManager::EnableTask, which is used to activate
     // and deactivate existing tasks, after they are created. Note: a disable task is considered

--- a/test/tests/testTaskManager.cpp
+++ b/test/tests/testTaskManager.cpp
@@ -49,9 +49,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 #include <pxr/usd/sdf/path.h>
 
 #if defined(__ANDROID__) || TARGET_OS_IPHONE == 1
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, DISABLED_TestTaskManager)
+HVT_TEST(TestViewportToolbox, DISABLED_TestTaskManager)
 #else
-HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestTaskManager)
+HVT_TEST(TestViewportToolbox, TestTaskManager)
 #endif
 {
     // The goal of the unit test is to validate the "TaskManager" and "FramePass" classes working
@@ -180,9 +180,8 @@ HVT_TEST_DEFAULT_BACKEND(TestViewportToolbox, TestTaskManager)
     // Validates the rendering result.
 
     const std::string computedFileName = TestHelpers::getComputedImagePath();
-    ASSERT_TRUE(testContext->_backend->saveImage(computedFileName));
-    ASSERT_TRUE(testContext->_backend->compareImage(
-        computedFileName, TestHelpers::gTestNames.fixtureName, 1));
+    ASSERT_TRUE(
+        testContext->validateImages(computedImageName, TestHelpers::gTestNames.fixtureName, 1));
 }
 
 namespace
@@ -294,7 +293,7 @@ HVT_TEST(TestViewportToolbox, TestTaskManagerCommitFn)
     ASSERT_EQ(params.blurAmount, 12.0f);
 
     // Override the existing task commit function with a new function.
-    constexpr float kNewBlurValue = 777.7;
+    constexpr float kNewBlurValue = 777.7f;
     taskManager->SetTaskCommitFn(pathBlur,
         [&](hvt::TaskManager::GetTaskValueFn const& /*fnGetValue*/,
             hvt::TaskManager::SetTaskValueFn const& fnSetValue)


### PR DESCRIPTION
The Vulkan tests are currently disabled. This PR introduces the HVT_TEST macro that will allow to parameterize which backends (OpenGL, Vulkan, etc...) are to be tested in a future PR.
Currently only OpenGL is tested.
