### PR TITLE
OGSMOD-8106 Fix unstable TestFramePasses unit tests

### DIFF
--- a/test/RenderingFramework/AndroidTestContext.cpp
+++ b/test/RenderingFramework/AndroidTestContext.cpp
@@ -88,6 +88,11 @@ void VulkanRendererContext::run(
     }
 }
 
+void VulkanRendererContext::waitForGPUIdle()
+{
+    queueWaitIdle();
+}
+
 bool VulkanRendererContext::saveImage(const std::string& fileName)
 {
     static const std::filesystem::path filePath = TestHelpers::getOutputDataFolder();
@@ -165,6 +170,18 @@ void VulkanRendererContext::createCommandBuffer(
     cmdBfrAllocInfo.commandBufferCount = 1;
     if (vkAllocateCommandBuffers(_device, &cmdBfrAllocInfo, &p_cmdBuf) != VK_SUCCESS)
         throw std::runtime_error("Create CommandBuffer - vkAllocateCommandBuffers failed");
+}
+
+void VulkanRendererContext::queueWaitIdle()
+{
+    pxr::HgiVulkan* hgiVulkan            = static_cast<pxr::HgiVulkan*>(_hgi.get());
+    pxr::HgiVulkanCommandQueue* hgiQueue =
+        hgiVulkan->GetPrimaryDevice()->GetCommandQueue();
+    if (!hgiQueue)
+        throw std::runtime_error("VulkanRendererContext::queueWaitIdle not found");
+
+    VkQueue gfxQueue = hgiQueue->GetVulkanGraphicsQueue();
+    vkQueueWaitIdle(gfxQueue);
 }
 
 void VulkanRendererContext::createTexture(

--- a/test/RenderingFramework/AndroidTestContext.h
+++ b/test/RenderingFramework/AndroidTestContext.h
@@ -48,8 +48,8 @@ public:
     void init();
     void shutdown() override;
     bool saveImage(const std::string& fileName) override;
-    void run(
-        std::function<bool()> render, hvt::FramePass* framePass) override;
+    void run(std::function<bool()> render, hvt::FramePass* framePass) override;
+    void waitForGPUIdle() override;
 
 private:
     pxr::HgiTextureHandle _dstTexture;
@@ -61,6 +61,8 @@ private:
 
     void createCommandPool(VkCommandPool& cmdPool);
     void destroyCommandPool(const VkCommandPool& cmdPool);
+
+    void queueWaitIdle();
 
     void createCommandBuffer(const VkCommandPool& cmdPool, VkCommandBuffer& cmdBuf);
     void beginCommandBuffer(const VkCommandBuffer& cmdBfr);

--- a/test/RenderingFramework/MetalTestContext.h
+++ b/test/RenderingFramework/MetalTestContext.h
@@ -35,6 +35,7 @@ public:
     bool saveImage(const std::string& fileName) override;
     void run(
         std::function<bool()> render, hvt::FramePass* framePass) override;
+    void waitForGPUIdle() override;
 
 protected:
     void beginMetal();

--- a/test/RenderingFramework/MetalTestContext.mm
+++ b/test/RenderingFramework/MetalTestContext.mm
@@ -235,6 +235,20 @@ MetalRendererContext::~MetalRendererContext()
     shutdown();
 }
 
+void MetalRendererContext::waitForGPUIdle()
+{
+    // Force all Metal command buffers to complete
+    pxr::HgiMetal* hgi = static_cast<pxr::HgiMetal*>(_hgi.get());
+    if (hgi)
+    {
+        // Tell Hydra that there is work to be submitted (even if the work was already submitted).
+        hgi->SetHasWork();
+        // Wait for the work to complete, even if the command buffer is empty. This also waits on
+        // previous calls to CommitPrimaryCommandBuffer() for any pending work.
+        hgi->CommitPrimaryCommandBuffer(pxr::HgiMetal::CommitCommandBuffer_WaitUntilCompleted);
+    }
+}
+
 void MetalRendererContext::init()
 {
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "metal");

--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -186,6 +186,12 @@ OpenGLRendererContext::~OpenGLRendererContext()
     shutdown();
 }
 
+void OpenGLRendererContext::waitForGPUIdle()
+{
+    // Wait for all GPU commands to complete.
+    glFinish();
+}
+
 void OpenGLRendererContext::init()
 {
     _glWindow.makeContextCurrent();

--- a/test/RenderingFramework/OpenGLTestContext.h
+++ b/test/RenderingFramework/OpenGLTestContext.h
@@ -52,8 +52,8 @@ public:
     bool saveImage(const std::string& fileName) override;
 
     /// Render the frame pass.
-    void run(std::function<bool()> render,
-        hvt::FramePass* framePass) override;
+    void run(std::function<bool()> render, hvt::FramePass* framePass) override;
+    void waitForGPUIdle() override;
 
 protected:
     void beginGL();

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -105,6 +105,7 @@ public:
     virtual void run(std::function<bool()> render, hvt::FramePass* framePass) = 0;
     virtual bool saveImage(const std::string& fileName)                       = 0;
     virtual void shutdown()                                                   = 0;
+    virtual void waitForGPUIdle(){};
 
     static std::string readImage(
         const std::string& fileName, int& width, int& height, int& channels);

--- a/test/RenderingFramework/VulkanTestContext.cpp
+++ b/test/RenderingFramework/VulkanTestContext.cpp
@@ -344,6 +344,11 @@ void VulkanRendererContext::run(std::function<bool()> render,
     }
 }
 
+void VulkanRendererContext::waitForGPUIdle()
+{
+    QueueWaitIdle();
+}
+
 bool VulkanRendererContext::saveImage(const std::string& fileName)
 {
     static const std::filesystem::path filePath = TestHelpers::getOutputDataFolder();

--- a/test/RenderingFramework/VulkanTestContext.h
+++ b/test/RenderingFramework/VulkanTestContext.h
@@ -90,9 +90,9 @@ public:
     void init();
     void shutdown() override;
     bool saveImage(const std::string& fileName) override;
-    void run(
-        std::function<bool()> render, hvt::FramePass* framePass) override;
-
+    void run(std::function<bool()> render, hvt::FramePass* framePass) override;
+    void waitForGPUIdle() override;
+    
     /// \brief Sets the final color buffer for copy-to-swapchain
     /// Call this before presenting so that Vulkan composition can
     /// happen before presentation

--- a/test/tests/testFramePasses.cpp
+++ b/test/tests/testFramePasses.cpp
@@ -482,6 +482,9 @@ TEST(TestViewportToolbox, TestFramePasses_MultiViewports)
 
             // Renders the frame pass.
             framePass1.sceneFramePass->Render();
+
+            // Force GPU sync
+            context->_backend->waitForGPUIdle();
         }
 
         // Gets the input AOV's from the first frame pass and use them in all overlays so the
@@ -613,6 +616,9 @@ TEST(TestViewportToolbox, TestFramePasses_MultiViewportsClearDepth)
 
             // Renders the frame pass.
             framePass1.sceneFramePass->Render();
+
+            // Force GPU sync
+            context->_backend->waitForGPUIdle();
         }
 
         // Gets the 'depth' input AOV from the first frame pass and use it in all overlays so the
@@ -737,6 +743,9 @@ TEST(TestViewportToolbox, TestFramePasses_TestDynamicAovInputs)
 
             // Renders the frame pass.
             framePass1.sceneFramePass->Render();
+
+            // Force GPU sync
+            context->_backend->waitForGPUIdle();
         }
 
         // Gets the input AOV's from the first frame pass and use them in all overlays so the
@@ -870,6 +879,9 @@ TEST(TestViewportToolbox, TestFramePasses_ClearDepthBuffer)
 
             // Renders the frame pass.
             framePass1.sceneFramePass->Render();
+
+            // Force GPU sync
+            context->_backend->waitForGPUIdle();
         }
 
         // Gets the 'depth' input AOV from the first frame pass and use it in all overlays so the
@@ -1007,6 +1019,9 @@ TEST(TestViewportToolbox, TestFramePasses_ClearColorBuffer)
 
             // Renders the frame pass.
             framePass1.sceneFramePass->Render();
+
+            // Force GPU sync
+            context->_backend->waitForGPUIdle();
         }
 
         // Gets the 'color' input AOV from the first frame pass and use it in all overlays so the


### PR DESCRIPTION
We recently realized some of our multi-pass unit tests were failing randomly:
- TestFramePasses_MultiViewports
- TestFramePasses_ClearColorBuffer
- TestFramePasses_TestDynamicAovInputs

This tends to happen more often when 2 consecutive frame passes that have a different lighting and camera settings, and our assumption was a buffer sync issue between the 1st and the 2 frame pass.

Waiting for the GPU to be idle before starting the 2nd frame pass is quite blunt, and we will have to implement a more tailored sync mechanism for supporting consecutive frame passes.

This is a transient solution.