### PR TITLE
OGSMOD-7669 - Enable HVT utest even if submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ endif()
 
 add_subdirectory("source")
 
-if (ENABLE_TESTS AND PROJECT_IS_TOP_LEVEL)
+if (ENABLE_TESTS)
     # Initialize CTest before adding test.
     enable_testing()
 


### PR DESCRIPTION
The pull request enables utests even if `HVT` is a submodule.