### PR TITLE
Add API unbindMaterial to SceneDataSource

### DIFF
--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -155,10 +155,10 @@ public:
     /// @return True on success.
     virtual bool bindMaterial(const PXR_NS::SdfPath& primPath, const PXR_NS::VtValue& mtlxDocument);
 
-    /// @brief Unbind any material from the primitive.
-    /// @param primPath Primitive path whose bound material should be removed.
-    /// @return True on success.
-    virtual bool unbindMaterial(const PXR_NS::SdfPath& primPath);
+    /// \brief Unbind any material from the primitive.
+    /// \param primPath Primitive path whose bound material should be removed.
+    /// \return True on success.
+    virtual bool unbindMaterial(PXR_NS::SdfPath const& primPath);
 
     /// @brief Update the value of specified material and property.
     /// @param matPrimPath Path of the material prim.

--- a/source/dataSource/dataSource.cpp
+++ b/source/dataSource/dataSource.cpp
@@ -70,7 +70,7 @@ bool SceneDataSource::bindMaterial(const SdfPath& /* primPath */, const VtValue&
     return false;
 }
 
-bool SceneDataSource::unbindMaterial(const SdfPath& /* primPath */)
+bool SceneDataSource::unbindMaterial(SdfPath const& /* primPath */)
 {
     TF_RUNTIME_ERROR("No implementation for SceneDataSource::unbindMaterial()");
     return false;


### PR DESCRIPTION
When performing interactive scene editing, it is necessary to be able to experimentally modify the materials bound to rprim, hence the need for this API. 