### PR TITLE
Add Black Duck security scan

### DIFF
--- a/.github/actions/coverage-report/action.yaml
+++ b/.github/actions/coverage-report/action.yaml
@@ -41,7 +41,6 @@ runs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       shell: bash
       run: |
-        echo "::group::Extract badge from CodeCoverageSummary markdown"
         BADGE_URL=$(grep -oP '!\[Code Coverage\]\(\K[^)]+' code-coverage-results.md | head -1)
         if [ -z "$BADGE_URL" ]; then
           echo "Error: Could not find badge URL in markdown"
@@ -52,13 +51,11 @@ runs:
         mkdir -p pages/coverage
         curl -s -o pages/coverage/coverage.svg "$BADGE_URL"
         echo "Badge saved to pages/coverage/coverage.svg"
-        echo "::endgroup::"
 
     - name: Add Date to Coverage Report
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       shell: bash
       run: |
-        echo "::group::Add generation date to coverage report"
         {
           cat code-coverage-results.md
           echo ""
@@ -66,7 +63,6 @@ runs:
           echo "**Report generated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
         } > code-coverage-dated-results.md
         echo "Date appended successfully"
-        echo "::endgroup::"
 
     - name: Generate Coverage HTML Report
       # Convert markdown to HTML to update the github pages

--- a/.github/workflows/black-duck-security.yml
+++ b/.github/workflows/black-duck-security.yml
@@ -1,0 +1,90 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# Black Duck Security Action allows you to integrate Software Composition Analysis (SCA)
+# into your CI/CD pipelines for third-party component vulnerability scanning.
+#
+# For more information about configuring your workflow,
+# read our documentation at https://github.com/blackduck-inc/black-duck-security-scan
+
+name: Black Duck Security Scan
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      # Note: Don't ignore .github/** for PRs - we want workflow changes to trigger scans
+  schedule:
+    # Run weekly scan on Mondays at 2 PM UTC
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+jobs:
+  black-duck-scan:
+    name: Black Duck SCA Scan
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: recursive
+
+      - name: Black Duck SCA Full Scan
+        id: black-duck-full-scan
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: blackduck-inc/black-duck-security-scan@v2
+        env:
+          DETECT_PROJECT_NAME: ${{ github.event.repository.name }}
+        with:
+          ### ---------- BLACKDUCK SCA SCANNING: REQUIRED FIELDS ----------
+          blackducksca_url: ${{ vars.BLACKDUCKSCA_URL }}
+          blackducksca_token: ${{ secrets.BLACKDUCKSCA_TOKEN }}          
+          ### ---------- SCAN CONFIGURATION ----------
+          blackducksca_scan_full: true
+          # Fail build on critical/blocker vulnerabilities
+          blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'          
+          ### ---------- SARIF REPORT GENERATION (for GitHub Security tab) ----------
+          blackducksca_reports_sarif_create: true
+          blackducksca_upload_sarif_report: true
+          blackducksca_reports_sarif_severities: 'CRITICAL,HIGH,MEDIUM'
+          blackducksca_reports_sarif_groupSCAIssues: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Black Duck SCA PR Scan
+        id: black-duck-pr-scan
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: blackduck-inc/black-duck-security-scan@v2
+        env:
+          DETECT_PROJECT_NAME: ${{ github.event.repository.name }}
+        with:
+          ### ---------- BLACKDUCK SCA SCANNING: REQUIRED FIELDS ----------
+          blackducksca_url: ${{ vars.BLACKDUCKSCA_URL }}
+          blackducksca_token: ${{ secrets.BLACKDUCKSCA_TOKEN }}          
+          ### ---------- PR SCAN CONFIGURATION ----------
+          blackducksca_scan_full: false          
+          ### ---------- PR COMMENT (automatically comment on PRs with scan results) ----------
+          blackducksca_prComment_enabled: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}          
+          ### ---------- SARIF REPORT GENERATION (for GitHub Security tab) ----------
+          blackducksca_reports_sarif_create: true
+          blackducksca_upload_sarif_report: true
+          blackducksca_reports_sarif_severities: 'CRITICAL,HIGH,MEDIUM'
+          blackducksca_reports_sarif_groupSCAIssues: true
+          
+


### PR DESCRIPTION
## Description

Add Black Duck security scan on the repo

### Changes Made

- PRs: Faster scan + automatic PR comments with results
- Pushes: Full scan + SARIF upload to Security tab
- Build protection: Fails on BLOCKER/CRITICAL vulnerabilities
- Better visibility: Results appear in both PR comments and Security tab
- Runs only on Linux platform using latest GitHub runners

## Testing

Test in a PR that the scan is running.

### Test Configuration
- **Platform(s) tested**: Linux

### Tests Performed
- [ ] Existing unit tests pass
- We can see from the logs it detects the cpp projects and scans the vcpkg dependencies

## Documentation

(https://documentation.blackduck.com/bundle/bridge/page/documentation/c_github-blackduck.html)

