### PR TITLE
OGSMOD-8159: Fix Black-Duck on main branch

### DIFF
--- a/.github/workflows/black-duck-security.yml
+++ b/.github/workflows/black-duck-security.yml
@@ -58,7 +58,10 @@ jobs:
           ### ---------- SCAN CONFIGURATION ----------
           blackducksca_scan_full: true
           # Fail build on critical/blocker vulnerabilities
-          blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'          
+          blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'
+          # Exclude signature scanner (not needed for vcpkg dependency scanning, and requires additional permissions)
+          # SCA (Software Composition Analysis) will still scan vcpkg.json dependencies
+          detect_args: '--detect.tools.excluded=SIGNATURE_SCAN'          
           ### ---------- SARIF REPORT GENERATION (for GitHub Security tab) ----------
           blackducksca_reports_sarif_create: true
           blackducksca_upload_sarif_report: true


### PR DESCRIPTION
## Description

Exclude signature scanner on full scans (not needed for vcpkg dependency scanning, and requires additional permissions)

### Changes Made

- Added detect_args: '--detect.tools.excluded=SIGNATURE_SCAN' to full scan steps.

## Testing

I inverted the full / partial scan to test it in the PR so I do not merge in main to discover the failure