### PR TITLE
Pass HdRendererCreateArgs in HdRenderSettingsMap with the desired Hgi

### DIFF
--- a/source/engine/renderIndexProxy.cpp
+++ b/source/engine/renderIndexProxy.cpp
@@ -44,16 +44,17 @@ namespace HVT_NS
 
 RenderIndexProxy::RenderIndexProxy(const std::string& rendererName, HdDriver* hgiDriver)
 {
-    Hgi* hgi = hgiDriver ? hgiDriver->driver.Get<Hgi*>() : nullptr;
-
     HdRenderSettingsMap settingsMap;
+#ifdef ADSK_OPENUSD_PENDING
+    Hgi* hgi = hgiDriver ? hgiDriver->driver.GetWithDefault<Hgi*>() : nullptr;
     if (hgi && hgiDriver->name == HgiTokens->renderDriver)
     {
-        if (hgi->GetAPIName() == HgiTokens->Vulkan)
-        {
-            settingsMap.insert(std::make_pair(TfToken("HgiBackend"), VtValue(HgiTokens->Vulkan)));
-        }
+        HdRendererCreateArgs rendererCreateArgs;
+        rendererCreateArgs.hgi = hgi;
+        rendererCreateArgs.gpuEnabled = true;
+        settingsMap.insert(std::make_pair(TfToken{"rendererCreateArgs"}, VtValue{rendererCreateArgs}));
     }
+#endif
 
     HdRendererPluginRegistry& registry = HdRendererPluginRegistry::GetInstance();
     _renderDelegate = registry.CreateRenderDelegate(TfToken(rendererName), settingsMap);


### PR DESCRIPTION
## Description
- `CreateRenderDelegate()` needs to know the `Hgi` in use, otherwise it can't correctly call `IsSupported()` internally. It uses the default Hgi and that may fail.
- This requires changes in USD which will be PR'd soon
- Current workaround is to use the `HGI_ENABLE_*` environment variables if applicable, such as `HGI_ENABLE_VULKAN`.