### PR TITLE
Use older name for GLFW_SCALE_FRAMEBUFFER (GLFW_COCOA_RETINA_FRAMEBUFFER)

### DIFF
--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -116,9 +116,7 @@ OpenGLWindow::OpenGLWindow(int w, int h)
     glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
 
-#ifdef GLFW_SCALE_FRAMEBUFFER
-    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
-#endif
+    glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
 
     if (isCoreProfile())
     {


### PR DESCRIPTION
No need to disable scaling, just use the old name mentioned in the doc...