### PR TITLE
Support Metal backed VkSurface

### DIFF
--- a/test/RenderingFramework/VulkanTestContext.h
+++ b/test/RenderingFramework/VulkanTestContext.h
@@ -47,6 +47,7 @@
 #define FRAME_BUFFER_COUNT 2
 
 struct SDL_Window;
+using SDL_MetalView = void*;
 
 /// Convenience helper functions for internal use in unit tests
 namespace TestHelpers
@@ -138,6 +139,9 @@ private:
     bool _compositeWithoutFramePass = false;
 
     SDL_Window* _mSDLWWindow = nullptr;
+#ifdef __APPLE__
+    SDL_MetalView _metalView{};
+#endif
     VkSurfaceKHR _surface;
     VkSwapchainKHR _swapChain;
     VkImage _swapchainImageList[FRAME_BUFFER_COUNT];


### PR DESCRIPTION
## Description
Vulkan builds on macOS, but tests crashed due to missing Vulkan surface creation logic. Thankfully with SDL it's easy to implement.