### PR TITLE
Use new GLFW scale hint name when available

### DIFF
--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -116,7 +116,11 @@ OpenGLWindow::OpenGLWindow(int w, int h)
     glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
 
+#ifdef GLFW_SCALE_FRAMEBUFFER
+    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+#else
     glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
+#endif
 
     if (isCoreProfile())
     {


### PR DESCRIPTION
## Description
Looks like `GLFW_COCOA_RETINA_FRAMEBUFFER` might be causing a GLX error on Linux? Not sure why, they're supposed to do the same thing.