### PR TITLE
OGSMOD-8326 - Change threshold for MSAA (on/off) utests

### DIFF
--- a/test/tests/testMultiSampling.cpp
+++ b/test/tests/testMultiSampling.cpp
@@ -26,7 +26,6 @@
 #include <hvt/tasks/resources.h>
 
 #include <pxr/base/plug/registry.h>
-#include <pxr/imaging/hgi/capabilities.h>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
## Description

The pull request does:

- change the pixel threshold for MSAA unit tests because the produced image is not consistent between runs.
- remove one useless method parameter.

## Tests Performed
- [X] Existing unit tests pass
- [X] Added/Updated unit test(s) for the changes
- [X] Tested on multiple platforms

## Documentation

- [X] Code is self-documenting / well-commented
- [X] Public API changes are documented with Doxygen comments

## Checklist

- [X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [X] My code follows the project's coding standards
- [X] My changes generate no new warnings or errors
