### PR TITLE
OGSMOD-8357: Allocate GPU for tests and deallocate after

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -25,7 +25,26 @@ on:
         type: boolean
 
 jobs:
+  start-vm:
+    name: Start GPU VM
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Start VM
+        run: |
+          az vm start --resource-group agp-rg-image-service --name AGP-U24T4-GPU-VM
+
   tests:
+    needs: start-vm
     uses: ./.github/workflows/ci-steps.yaml
     with:
       runner: gpu
@@ -35,4 +54,23 @@ jobs:
 
     secrets:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
-  
+
+  stop-vm:
+    name: Deallocate GPU VM
+    needs: [start-vm, tests]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deallocate VM
+        run: |
+          az vm deallocate --resource-group agp-rg-image-service --name AGP-U24T4-GPU-VM

--- a/README.md
+++ b/README.md
@@ -52,17 +52,28 @@ For more information or to customize the configuration, see [Using CMake Presets
 
 CI builds and tests are run via GitHub Actions using shared CMake presets.
 
-### CI Minimal
+### CI GPU Tests
 
-A lightweight CI workflow (`ci-minimal.yaml`) runs automatically on every pull request and push, building and testing on Linux (Debug) by default.
+A specialized workflow (`ci-test.yaml`) executes hardware-accelerated tests on a dedicated Linux VM equipped with an NVIDIA GPU. This workflow automatically allocates the cloud VM at the start of the job and deallocates it upon completion.
 
-It can also be run manually with custom options to test a specific platform (`windows`, `linux`, or `macos`) and configuration (`debug` or `release`) by selecting from the “Run workflow” button in GitHub Actions.
+It runs exclusively on:
+- Every Pull Request (after approval for external contributors).
+- Every push to the `main` branch.
+
+It will not be able to spawn GPU VM for other scenarios.
+
+These tests ensure that HVT features work correctly on actual GPU hardware and modern NVIDIA drivers.
 
 ### CI Full
 
-A full matrix workflow (`ci-full.yaml`) tests on Linux with both Debug and Release configurations. This does not run by default on every PR.
+A full matrix workflow (`ci-full.yaml`) tests on Linux, macOS, and Windows with both Debug and Release configurations. This does not run by default on every PR.
 To run it manually, use the “Run workflow” button under the “Actions” tab on GitHub after pushing your branch.
-It also runs when a PR merges into main.
+It also runs when a PR merges into `main`.
+
+### CI Minimal
+
+A lightweight CI workflow (`ci-minimal.yaml`) used for quick verification. 
+This workflow does not run automatically. It can be run manually with custom options to test a specific platform (`windows`, `linux`, or `macos`) and configuration (`debug` or `release`) by selecting from the “Run workflow” button in GitHub Actions.
 
 ## vcpkg Integration
 


### PR DESCRIPTION
## Description

To save costs on self hosted GitHub runners hosting GPU, we allocate before running a test job and deallocate when the jobs terminates, success or not.

Allocation takes approximately 40s so it is reasonable to avoid excessive costs of having an VM up 24/7.

### Changes Made

- Added logic in the test pipeline to allocate the VM before running the tests and after running the tests to deallocate.
- Added three secret to the HVT repo: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID to allow gut hub to communicate with Azure.
- In Azure portal, added Federated Credentials in app_d_aoai-sandbox-ci-helper for hvt main branch and hvt PRs requests. Any other origin for the request won't be allowed to allocate a VM.
- In Azure portal, added a Virtual Machine Contributor Role assignment to the agp-rg-image-service for the app_d_aoai-sandbox-ci-helper 

## Testing

To test this feature, I deallocate the VM, create the PR, check if the test pipeline triggers the VM allocation.
At the end of the pipeline, the VM should be deallocated.
All these new steps should be clearly visible in the pipeline.
