### PR TITLE
OGSMOD-8425: Define binary files in .gitattributes to fix Black Duck scan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,10 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+
+###############################################################################
+# Explicitly mark binary files to prevent text-diff parsing errors (Black Duck)
+###############################################################################
+*.png binary
+*.usdz binary
+*.docx binary


### PR DESCRIPTION
## Description

This PR resolves a failure in the Black Duck SCA security pipeline where the GitHub Commenter would crash when processing Pull Requests. The issue was caused by the scanner attempting to parse binary files (specifically test baseline PNGs) as text-based unified diffs.
By explicitly marking these extensions as binary in .gitattributes, Git will no longer generate line-based diffs for them, allowing the Black Duck parser to safely skip these files.

### Changes Made

- Updated .gitattributes to explicitly mark .png, .usdz, and .docx files as binary.
- Added a configuration section to .gitattributes specifically to address Black Duck diff parsing errors.
- Verified that these are the only binary extensions currently tracked in the repository.

## Testing

- Manually verified tracked binary files using git ls-files.
- Verified that git diff now correctly identifies these assets as binary (e.g., "Binary files differ" instead of attempting to show content changes).

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 -->
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: <!-- e.g., v24.08 -->
