### PR TITLE
AGP-90 - Add perf. macros for run() measures

### DIFF
--- a/source/engine/framePass.cpp
+++ b/source/engine/framePass.cpp
@@ -284,6 +284,7 @@ void FramePass::UpdateScene(UsdTimeCode /*frame*/) {}
 HdTaskSharedPtrVector FramePass::GetRenderTasks(RenderBufferBindings const& inputAOVs)
 {
     HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
 
     _bufferManager->SetBufferSizeAndMsaa(
         _passParams.renderBufferSize, _passParams.msaaSampleCount, _passParams.enableMultisampling);

--- a/source/engine/taskManager.cpp
+++ b/source/engine/taskManager.cpp
@@ -339,6 +339,9 @@ void TaskManager::SetTaskValue(SdfPath const& uid, TfToken const& key, VtValue c
 
 HdTaskSharedPtrVector const TaskManager::GetTasks(TaskFlags taskFlags) const
 {
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
     HdTaskSharedPtrVector filteredTasks;
 
     for (TaskEntry const& task : _tasks)

--- a/source/engine/viewportEngine.cpp
+++ b/source/engine/viewportEngine.cpp
@@ -278,6 +278,7 @@ void UpdateSceneDelegate(
     SceneDelegatePtr& sceneDelegate, UsdTimeCode frame, int refineLevelFallback)
 {
     HD_TRACE_FUNCTION();
+
     if (!sceneDelegate)
         return;
 
@@ -311,6 +312,8 @@ void UpdateSceneDelegates(std::vector<SceneDelegatePtr>& sceneDelegates, UsdTime
 
 void UpdateUSDSceneIndex(UsdImagingStageSceneIndexRefPtr& sceneIndex, UsdTimeCode frame)
 {
+    HD_TRACE_FUNCTION();
+
     if (!sceneIndex)
         return;
 
@@ -783,6 +786,8 @@ void UpdatePrim(UsdStageRefPtr& stage, const SdfPath& path, const GfVec3d& posit
     const GfRotation& rotation, float scale, bool isVisible,
     const std::map<SdfPath, bool>& visibilityOverrides)
 {
+    HD_TRACE_FUNCTION();
+
     if (!stage)
     {
         return;

--- a/source/tasks/aovInputTask.cpp
+++ b/source/tasks/aovInputTask.cpp
@@ -99,6 +99,9 @@ void AovInputTask::_Sync(
 
 void AovInputTask::Prepare(HdTaskContext* /* ctx */, HdRenderIndex* /* renderIndex */)
 {
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
     // Wrap one HdEngine::Execute frame with Hgi StartFrame and EndFrame.
     // EndFrame is currently called in the PresentTask.
     // This is important for Hgi garbage collection to run.

--- a/test/RenderingFramework/MetalTestContext.mm
+++ b/test/RenderingFramework/MetalTestContext.mm
@@ -241,6 +241,8 @@ MetalRendererContext::~MetalRendererContext()
 
 void MetalRendererContext::waitForGPUIdle()
 {
+    HD_TRACE_FUNCTION();
+
     // Force all Metal command buffers to complete
     pxr::HgiMetal* hgi = static_cast<pxr::HgiMetal*>(_hgi.get());
     if (hgi)
@@ -327,6 +329,8 @@ void MetalRendererContext::endMetal()
 
 void MetalRendererContext::run(std::function<bool()> render, hvt::FramePass* framePass)
 {
+    HD_TRACE_FUNCTION();
+
     bool moreFrames = true;
     while (moreFrames)
     {

--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -198,6 +198,8 @@ OpenGLRendererContext::~OpenGLRendererContext()
 
 void OpenGLRendererContext::waitForGPUIdle()
 {
+    HD_TRACE_FUNCTION();
+
     // Wait for all GPU commands to complete.
     glFinish();
 }
@@ -257,6 +259,8 @@ void OpenGLRendererContext::endGL()
 void OpenGLRendererContext::run(
     std::function<bool()> render, hvt::FramePass* /* framePass */)
 {
+    HD_TRACE_FUNCTION();
+
     while (!_glWindow.windowShouldClose())
     {
         bool moreFrames = true;

--- a/test/tests/testVisualizeAOV.cpp
+++ b/test/tests/testVisualizeAOV.cpp
@@ -29,6 +29,9 @@ namespace
 
 void TestDisplayAOV(std::shared_ptr<TestHelpers::TestContext>& context, pxr::TfToken const& aovToken)
 {
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
     TestHelpers::TestStage stage(context->_backend);
 
     // Use a dedicated scene with three rectangles at different depths for better depth visualization.


### PR DESCRIPTION
## Description

The pull request only adds macros to have better performance measures for run() (i.e., display of the model). To be generic it uses the `OpenUSD` macros.

## Documentation

- [X] Code is self-documenting / well-commented
- [X] Public API changes are documented with Doxygen comments

## Checklist

- [X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [X] My code follows the project's coding standards
- [X] My changes generate no new warnings or errors
