### PR TITLE
Update README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -140,7 +140,7 @@ Once a frame pass is created its parameters can be set on it to control how the 
 auto& params = sceneFramePass->params();
 
 params.renderBufferSize          = pxr::GfVec2i(context.width(), context.height());
-params.viewInfo.viewport         = { { 0, 0 }, { context.width(), context.height() } };
+params.viewInfo.framing          = hvt::ViewParams::GetDefaultFraming(context.width(), context.height());
 params.viewInfo.viewMatrix       = stage.viewMatrix();
 params.viewInfo.projectionMatrix = stage.projectionMatrix();
 


### PR DESCRIPTION
## Description
ViewParams doesn't have a "viewport" entry. Replacing it with "framing"

