### PR TITLE
[Paging] Fix random test failures

### DIFF
--- a/include/hvt/pageableBuffer/pageableBufferManager.h
+++ b/include/hvt/pageableBuffer/pageableBufferManager.h
@@ -667,12 +667,12 @@ std::future<std::invoke_result_t<Callable>> HdPageableBufferManager<PagingStrate
         if constexpr (std::is_void_v<ResultType>)
         {
             task();
-            mPendingTaskCount.fetch_sub(1);
+            mPendingTaskCount.fetch_sub(1, std::memory_order_relaxed);
         }
         else
         {
             ResultType result = task();
-            mPendingTaskCount.fetch_sub(1);
+            mPendingTaskCount.fetch_sub(1, std::memory_order_relaxed);
             return result;
         }
     };

--- a/include/hvt/pageableBuffer/pageableBufferManager.h
+++ b/include/hvt/pageableBuffer/pageableBufferManager.h
@@ -660,9 +660,25 @@ std::future<std::invoke_result_t<Callable>> HdPageableBufferManager<PagingStrate
         return std::future<ResultType>();
     }
 
-    // Create a packaged_task to get a future
+    // Create a packaged_task to get a future. To ensure correct pending task count, wrap the 
+    // callable so mPendingTaskCount is decremented before the packaged_task marks the future ready.
+    auto wrappedTask = [this, task = std::forward<Callable>(task)]() mutable -> ResultType
+    {
+        if constexpr (std::is_void_v<ResultType>)
+        {
+            task();
+            mPendingTaskCount.fetch_sub(1);
+        }
+        else
+        {
+            ResultType result = task();
+            mPendingTaskCount.fetch_sub(1);
+            return result;
+        }
+    };
+
     auto packagedTask =
-        std::make_shared<std::packaged_task<ResultType()>>(std::forward<Callable>(task));
+        std::make_shared<std::packaged_task<ResultType()>>(std::move(wrappedTask));
     auto future = packagedTask->get_future();
 
     // Submit task
@@ -671,10 +687,9 @@ std::future<std::invoke_result_t<Callable>> HdPageableBufferManager<PagingStrate
         [this, packagedTask]()
         {
             mTaskGroup->run(
-                [this, packagedTask]()
+                [packagedTask]()
                 {
                     (*packagedTask)();
-                    mPendingTaskCount.fetch_sub(1);
                 });
         });
 

--- a/source/pageableBuffer/pageFileManager.cpp
+++ b/source/pageableBuffer/pageFileManager.cpp
@@ -179,7 +179,12 @@ bool HdPageFileEntry::WriteData(std::ptrdiff_t offset, const void* data, size_t 
     // nullptr is allowed for buffers with scene state but no backing storage
     if (data)
     {
+        mFile.clear();
         mFile.seekp(offset);
+        if (!mFile.good())
+        {
+            return false;
+        }
         mFile.write(static_cast<const char*>(data), static_cast<std::streamsize>(size));
         mFile.flush();
     }
@@ -196,7 +201,12 @@ bool HdPageFileEntry::ReadData(std::ptrdiff_t offset, void* data, size_t size)
 
     if (data)
     {
+        mFile.clear();
         mFile.seekg(offset);
+        if (!mFile.good())
+        {
+            return false;
+        }
         mFile.read(static_cast<char*>(data), static_cast<std::streamsize>(size));
     }
     return mFile && mFile.gcount() == static_cast<std::streamsize>(size);

--- a/source/pageableBuffer/pageFileManager.cpp
+++ b/source/pageableBuffer/pageFileManager.cpp
@@ -181,7 +181,7 @@ bool HdPageFileEntry::WriteData(std::ptrdiff_t offset, const void* data, size_t 
     {
         mFile.clear();
         mFile.seekp(offset);
-        if (!mFile.good())
+        if (!mFile)
         {
             return false;
         }
@@ -203,7 +203,7 @@ bool HdPageFileEntry::ReadData(std::ptrdiff_t offset, void* data, size_t size)
     {
         mFile.clear();
         mFile.seekg(offset);
-        if (!mFile.good())
+        if (!mFile)
         {
             return false;
         }

--- a/source/pageableBuffer/pageableMemoryMonitor.cpp
+++ b/source/pageableBuffer/pageableMemoryMonitor.cpp
@@ -57,13 +57,9 @@ void HdMemoryMonitor::AddSceneMemory(size_t size)
 void HdMemoryMonitor::ReduceSceneMemory(size_t size)
 {
     size_t current = mUsedSceneMemory.load(std::memory_order_relaxed);
-    size_t desired;
-    do
-    {
-        // Set to zero if trying to subtract more than available
-        desired = (current < size) ? 0 : (current - size);
-    } while (!mUsedSceneMemory.compare_exchange_weak(
-        current, desired, std::memory_order_relaxed, std::memory_order_relaxed));
+    // Set to zero if trying to subtract more than available
+    while (!mUsedSceneMemory.compare_exchange_strong(current, (current < size) ? 0 : (current - size),
+        std::memory_order_relaxed, std::memory_order_relaxed));
 }
 
 void HdMemoryMonitor::AddRendererMemory(size_t size)
@@ -74,13 +70,9 @@ void HdMemoryMonitor::AddRendererMemory(size_t size)
 void HdMemoryMonitor::ReduceRendererMemory(size_t size)
 {
     size_t current = mUsedRendererMemory.load(std::memory_order_relaxed);
-    size_t desired;
-    do
-    {
-        // Set to zero if trying to subtract more than available
-        desired = (current < size) ? 0 : (current - size);
-    } while (!mUsedRendererMemory.compare_exchange_weak(
-        current, desired, std::memory_order_relaxed, std::memory_order_relaxed));
+    // Set to zero if trying to subtract more than available
+    while (!mUsedRendererMemory.compare_exchange_strong(current, (current < size) ? 0 : (current - size),
+        std::memory_order_relaxed, std::memory_order_relaxed));
 }
 
 float HdMemoryMonitor::GetSceneMemoryPressure() const

--- a/source/pageableBuffer/pageableMemoryMonitor.cpp
+++ b/source/pageableBuffer/pageableMemoryMonitor.cpp
@@ -51,39 +51,36 @@ HdMemoryMonitor::HdMemoryMonitor(size_t sceneMemoryLimit, size_t rendererMemoryL
 
 void HdMemoryMonitor::AddSceneMemory(size_t size)
 {
-    mUsedSceneMemory += size;
+    mUsedSceneMemory.fetch_add(size, std::memory_order_relaxed);
 }
 
 void HdMemoryMonitor::ReduceSceneMemory(size_t size)
 {
-    size_t current = mUsedSceneMemory.load();
-    if (current < size)
+    size_t current = mUsedSceneMemory.load(std::memory_order_relaxed);
+    size_t desired;
+    do
     {
         // Set to zero if trying to subtract more than available
-        mUsedSceneMemory = 0;
-    }
-    else
-    {
-        mUsedSceneMemory -= size;
-    }
+        desired = (current < size) ? 0 : (current - size);
+    } while (!mUsedSceneMemory.compare_exchange_weak(
+        current, desired, std::memory_order_relaxed, std::memory_order_relaxed));
 }
 
 void HdMemoryMonitor::AddRendererMemory(size_t size)
 {
-    mUsedRendererMemory += size;
+    mUsedRendererMemory.fetch_add(size, std::memory_order_relaxed);
 }
 
 void HdMemoryMonitor::ReduceRendererMemory(size_t size)
 {
-    size_t current = mUsedRendererMemory.load();
-    if (current < size)
+    size_t current = mUsedRendererMemory.load(std::memory_order_relaxed);
+    size_t desired;
+    do
     {
-        mUsedRendererMemory = 0;
-    }
-    else
-    {
-        mUsedRendererMemory -= size;
-    }
+        // Set to zero if trying to subtract more than available
+        desired = (current < size) ? 0 : (current - size);
+    } while (!mUsedRendererMemory.compare_exchange_weak(
+        current, desired, std::memory_order_relaxed, std::memory_order_relaxed));
 }
 
 float HdMemoryMonitor::GetSceneMemoryPressure() const

--- a/source/pageableBuffer/pageableMemoryMonitor.cpp
+++ b/source/pageableBuffer/pageableMemoryMonitor.cpp
@@ -58,8 +58,8 @@ void HdMemoryMonitor::ReduceSceneMemory(size_t size)
 {
     size_t current = mUsedSceneMemory.load(std::memory_order_relaxed);
     // Set to zero if trying to subtract more than available
-    while (!mUsedSceneMemory.compare_exchange_strong(current, (current < size) ? 0 : (current - size),
-        std::memory_order_relaxed, std::memory_order_relaxed));
+    while (!mUsedSceneMemory.compare_exchange_strong(
+        current, (current < size) ? 0 : (current - size), std::memory_order_relaxed));
 }
 
 void HdMemoryMonitor::AddRendererMemory(size_t size)
@@ -71,8 +71,8 @@ void HdMemoryMonitor::ReduceRendererMemory(size_t size)
 {
     size_t current = mUsedRendererMemory.load(std::memory_order_relaxed);
     // Set to zero if trying to subtract more than available
-    while (!mUsedRendererMemory.compare_exchange_strong(current, (current < size) ? 0 : (current - size),
-        std::memory_order_relaxed, std::memory_order_relaxed));
+    while (!mUsedRendererMemory.compare_exchange_strong(
+        current, (current < size) ? 0 : (current - size), std::memory_order_relaxed));
 }
 
 float HdMemoryMonitor::GetSceneMemoryPressure() const


### PR DESCRIPTION
### Changes Made

- Change mPendingTaskCount decrement order to ensure it's updated before user getting future.
- Fix memory counter update race.
- Clear potential file failed status.

## Testing

I found there're random failures on Linux, yet cannot reproduce that. The fix is made by analyzing the logic and automation results. And again, limit the potential perf impact.

### Test Configuration
- **Platform(s) tested**: Windows 11, Ubuntu 22.04, macOS 14.2
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: <!-- e.g., v24.08 -->

### Tests Performed
<!-- Check all that apply -->
- [x] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [x] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [ ] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [ ] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [ ] My code follows the project's coding standards
- [ ] My changes generate no new warnings or errors
