### PR TITLE
AGP-309 - Improve the VCPKG_ROOT support

### DIFF
--- a/cmake/VcpkgChooseTriplet.cmake
+++ b/cmake/VcpkgChooseTriplet.cmake
@@ -42,7 +42,11 @@ if(NOT HVT_BASE_TRIPLET_FILE)
     endif()
 
     # Define root of vcpkg
-    set(vcpkg_root "${CMAKE_CURRENT_LIST_DIR}/../externals/vcpkg")
+    if(DEFINED ENV{VCPKG_ROOT})
+        set(vcpkg_root "$ENV{VCPKG_ROOT}")
+    else()
+        set(vcpkg_root "${CMAKE_CURRENT_LIST_DIR}/../externals/vcpkg")
+    endif()
     cmake_path(NORMAL_PATH vcpkg_root)
 
     # Try primary location

--- a/cmake/VcpkgChooseTriplet.cmake
+++ b/cmake/VcpkgChooseTriplet.cmake
@@ -43,7 +43,9 @@ if(NOT HVT_BASE_TRIPLET_FILE)
 
     # Define root of vcpkg
     if(DEFINED ENV{VCPKG_ROOT})
-        set(vcpkg_root "$ENV{VCPKG_ROOT}")
+        # Take and normalize so backslashes from Windows env vars are not
+        # written into CMake files.
+        file(TO_CMAKE_PATH "$ENV{VCPKG_ROOT}" vcpkg_root)
     else()
         set(vcpkg_root "${CMAKE_CURRENT_LIST_DIR}/../externals/vcpkg")
     endif()

--- a/cmake/VcpkgSetup.cmake
+++ b/cmake/VcpkgSetup.cmake
@@ -45,10 +45,8 @@ endif()
 if(DEFINED ENV{VCPKG_ROOT})
     set(vcpkg_dir "$ENV{VCPKG_ROOT}")
 
-    if(NOT EXISTS "${vcpkg_dir}/ports")
-        message(STATUS "Initializing vcpkg...")
-        execute_process(COMMAND git clone https://github.com/microsoft/vcpkg.git "${vcpkg_dir}" 
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND_ERROR_IS_FATAL ANY)
+    if(NOT EXISTS "${vcpkg_dir}")
+        message(FATAL_ERROR "The vcpkg clone is missing: ${vcpkg_dir}")
     endif()
 else()
     set(vcpkg_dir "${CMAKE_SOURCE_DIR}/externals/vcpkg")

--- a/cmake/VcpkgSetup.cmake
+++ b/cmake/VcpkgSetup.cmake
@@ -42,7 +42,11 @@ if(NOT VCPKG_MANIFEST_FEATURES)
   return()
 endif()
 
-set(vcpkg_dir "${CMAKE_SOURCE_DIR}/externals/vcpkg")
+if(DEFINED ENV{VCPKG_ROOT})
+    set(vcpkg_dir "$ENV{VCPKG_ROOT}")
+else()
+    set(vcpkg_dir "${CMAKE_SOURCE_DIR}/externals/vcpkg")
+endif()
 if(NOT EXISTS "${vcpkg_dir}/ports")
     message(STATUS "Initializing vcpkg submodule...")
     execute_process(COMMAND git submodule update --init --recursive

--- a/cmake/VcpkgSetup.cmake
+++ b/cmake/VcpkgSetup.cmake
@@ -44,13 +44,20 @@ endif()
 
 if(DEFINED ENV{VCPKG_ROOT})
     set(vcpkg_dir "$ENV{VCPKG_ROOT}")
+
+    if(NOT EXISTS "${vcpkg_dir}/ports")
+        message(STATUS "Initializing vcpkg...")
+        execute_process(COMMAND git clone https://github.com/microsoft/vcpkg.git "${vcpkg_dir}" 
+            COMMAND_ERROR_IS_FATAL ANY)
+    endif()
 else()
     set(vcpkg_dir "${CMAKE_SOURCE_DIR}/externals/vcpkg")
-endif()
-if(NOT EXISTS "${vcpkg_dir}/ports")
-    message(STATUS "Initializing vcpkg submodule...")
-    execute_process(COMMAND git submodule update --init --recursive
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND_ERROR_IS_FATAL ANY)
+
+    if(NOT EXISTS "${vcpkg_dir}/ports")
+        message(STATUS "Initializing vcpkg submodule...")
+        execute_process(COMMAND git submodule update --init --recursive
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND_ERROR_IS_FATAL ANY)
+    endif()
 endif()
 
 # Define the toolchain if it was not already defined in the command line

--- a/cmake/VcpkgSetup.cmake
+++ b/cmake/VcpkgSetup.cmake
@@ -43,7 +43,9 @@ if(NOT VCPKG_MANIFEST_FEATURES)
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT})
-    set(vcpkg_dir "$ENV{VCPKG_ROOT}")
+    # Take and normalize so backslashes from Windows env vars are not
+    # written into CMake files.
+    file(TO_CMAKE_PATH "$ENV{VCPKG_ROOT}" vcpkg_dir)
 
     if(NOT EXISTS "${vcpkg_dir}")
         message(FATAL_ERROR "The vcpkg clone is missing: ${vcpkg_dir}")

--- a/cmake/VcpkgSetup.cmake
+++ b/cmake/VcpkgSetup.cmake
@@ -48,7 +48,7 @@ if(DEFINED ENV{VCPKG_ROOT})
     if(NOT EXISTS "${vcpkg_dir}/ports")
         message(STATUS "Initializing vcpkg...")
         execute_process(COMMAND git clone https://github.com/microsoft/vcpkg.git "${vcpkg_dir}" 
-            COMMAND_ERROR_IS_FATAL ANY)
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" COMMAND_ERROR_IS_FATAL ANY)
     endif()
 else()
     set(vcpkg_dir "${CMAKE_SOURCE_DIR}/externals/vcpkg")

--- a/test/tests/testPageableBuffer.cpp
+++ b/test/tests/testPageableBuffer.cpp
@@ -183,7 +183,12 @@ TEST(TestPageableBuffer, BasicPageableBuffer)
     GTEST_SUCCEED();
 }
 
+// FIXME: Refer to AGP-276
+#if defined(__APPLE__)
+TEST(TestPageableBuffer, DISABLED_MemoryPressure)
+#else
 TEST(TestPageableBuffer, MemoryPressure)
+#endif
 {
     hvt::DefaultBufferManager::InitializeDesc desc;
     desc.pageFileDirectory = std::filesystem::temp_directory_path() / "hvt_test_pages";
@@ -198,8 +203,9 @@ TEST(TestPageableBuffer, MemoryPressure)
     std::vector<std::shared_ptr<hvt::HdPageableBufferCore>> buffers;
     for (int i = 0; i < 20; ++i)
     {
-        std::string bufferName = "/Buffer" + std::to_string(i);
-        auto buffer            = bufferManager.CreateBuffer(PXR_NS::SdfPath(bufferName), 30 * hvt::ONE_MiB);
+        const std::string bufferName = "/Buffer" + std::to_string(i);
+        auto buffer = bufferManager.CreateBuffer(PXR_NS::SdfPath(bufferName), 30 * hvt::ONE_MiB);
+        EXPECT_TRUE(buffer != nullptr);
 
         // Age some buffers
         if (i < 10)


### PR DESCRIPTION
## Description

The pull request adds the support to the expected `VCPKG_ROOT` env. variable support which provides a custom vcpkg directory. The main usage in my case , is to share the third-party build/binaries between all the `HVT` clones.

## Checklist

- [X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [X] My code follows the project's coding standards
- [X] My changes generate no new warnings or errors
