### PR TITLE
AGP-397 - Fix WBOIT

### DIFF
--- a/include/hvt/engine/framePass.h
+++ b/include/hvt/engine/framePass.h
@@ -327,7 +327,13 @@ public:
 
     /// Accessor for the input parameters for this frame pass.
     /// \return A collection of parameters that can be set for this frame pass.
-    inline const FramePassParams& params() const { return _passParams; }
+    inline FramePassParams const& params() const { return _passParams; }
+
+    /// Accessor for the task creation options.
+    /// \note This is used to control the task creation options for this frame pass so it
+    /// can be a read-only accessor.
+    /// \return The task creation options.
+    inline TaskCreationOptions const& taskCreationOptions() const { return _taskCreationOptions; }
 
     /// Gets the display window position & dimension.
     inline const PXR_NS::GfRange2f GetDisplayWindow() const

--- a/source/tasks/wboitRenderTask.cpp
+++ b/source/tasks/wboitRenderTask.cpp
@@ -229,7 +229,7 @@ bool WbOitRenderTask::_InitTextures(
         for (size_t i = 0; i < aovOutputs.size(); ++i)
         {
             TfToken const& aovOutput = aovOutputs[i];
-            SdfPath const aovId      = SdfPath("wboitBuffer" + std::to_string(i));
+            SdfPath const aovId      = GetId().AppendChild(TfToken("wboitBuffer" + std::to_string(i)));
 
             _wboitBuffers.push_back(
                 std::make_unique<HdStRenderBuffer>(hdStResourceRegistry.get(), aovId));


### PR DESCRIPTION
## Description

The pull request only fixes a small glitches when managing two WBOIT instances (in two different frame passes for example) and adds a read-only access to see what task OIT task (Linked OIT or WBOIT) was created.

As the WBOIT buffers are managed by the global resource manager, their path must be unique.

### Tests Performed
- [X] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [X] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

- [X] Code is self-documenting / well-commented
- [X] Public API changes are documented with Doxygen comments

## Checklist

- [X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [X] My code follows the project's coding standards
- [X] My changes generate no new warnings or errors
