### PR TITLE
Fix Linux compilation of  "HdxColorizeSelectionTaskParams initialParams"

### DIFF
--- a/source/engine/taskCreationHelpers.cpp
+++ b/source/engine/taskCreationHelpers.cpp
@@ -448,7 +448,7 @@ SdfPath CreateSelectionTask(
         }
     };
 
-    HdxSelectionTaskParams initialParams;
+    HdxSelectionTaskParams initialParams{};
     initialParams.enableSelectionHighlight = true;
     initialParams.enableLocateHighlight    = true;
     initialParams.selectionColor           = GfVec4f(1, 1, 0, 1);
@@ -485,7 +485,7 @@ SdfPath CreateColorizeSelectionTask(
         }
     };
 
-    HdxColorizeSelectionTaskParams initialParams;
+    HdxColorizeSelectionTaskParams initialParams{};
     initialParams.enableSelectionHighlight = true;
     initialParams.selectionColor           = GfVec4f(1, 1, 0, 1);
     initialParams.locateColor              = GfVec4f(0, 0, 1, 1);


### PR DESCRIPTION
## Description

Add brackets to ensure default-initialization of HdxColorizeSelectionTaskParams at two places, this was causing compilation issues on some of our Linux machines.

### Tests Performed
- [X] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [X] Tested on multiple platforms
- [X] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
