### PR TITLE
Area light editing protocol

### DIFF
--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -227,11 +227,6 @@ public:
         PXR_NS::TfToken const& attrName, PXR_NS::VtValue const& value);
 
     /// \brief Reads the current value of an attribute on a prim.
-    /// Symmetric counterpart to updatePrimAttribute, used by UI to seed
-    /// widget state from the actual prim values (e.g. show the correct
-    /// shadow toggle / radius / intensity for a UsdLux light loaded from
-    /// a USD file). Returns false (and leaves outValue untouched) when
-    /// the prim or attribute doesn't exist or is not authored.
     /// \param primPath Path to the prim.
     /// \param attrName Attribute token.
     /// \param outValue Receives the current value on success.
@@ -241,24 +236,15 @@ public:
 
     /// \brief Returns the number of area light prims currently in the
     ///        scene.
-    /// Split from getAreaLight so callers that only need a count (e.g.
-    /// "are there any?" / "do we need to show the panel?") don't have to
-    /// pay for materializing the full list of paths and types. Indices
-    /// passed to getAreaLight are valid in the range [0, count).
     /// \return Number of area light prims, or 0 when none / no scene.
-    virtual int getAreaLightCount() const;
+    virtual size_t getAreaLightCount() const;
 
     /// \brief Retrieves the i-th area light's path and concrete type.
-    /// Symmetric counterpart to getAreaLightCount; callers that need the
-    /// full list iterate from 0 to getAreaLightCount() - 1. The traversal
-    /// order is determined by the data source and is required only to be
-    /// stable for the duration of a single sequence of calls (no scene
-    /// mutation between calls).
     /// \param index Zero-based index into the area light set.
     /// \param outInfo Receives the path and type on success; left
     ///                untouched on failure.
     /// \return True when index is in range and outInfo was populated.
-    virtual bool getAreaLight(int index, AreaLightInfo& outInfo) const;
+    virtual bool getAreaLight(size_t index, AreaLightInfo& outInfo) const;
 
     virtual void setRefineLevelFallback(int refineLevelFallback)
     {

--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -186,7 +186,8 @@ public:
     {
         NoFeatures               = 0x00,
         PrimitiveTransformations = 0x01,
-        PrimitiveDeletion        = 0x02
+        PrimitiveDeletion        = 0x02,
+        AreaLightEditing         = 0x04
     };
 
     /// Returns the set of supported features.
@@ -196,6 +197,52 @@ public:
     /// \param path The set of primitive paths.
     /// \return True if successful.
     virtual bool erasePrimitives(PXR_NS::SdfPathSet const&) { return false; }
+
+    /// Area light type used by createAreaLight.
+    enum class AreaLightType { Rect, Disk, Sphere, Cylinder };
+
+    /// Bundles the prim path of an area light with its concrete type so
+    /// callers (e.g. UI) can present type-specific controls without
+    /// re-querying the underlying scene. Returned by enumerateAreaLights.
+    struct AreaLightInfo
+    {
+        PXR_NS::SdfPath path;
+        AreaLightType   type;
+    };
+
+    /// \brief Creates a new area light prim of the specified type.
+    /// \param type The area light type (Rect, Disk, Sphere, Cylinder).
+    /// \param path The prim path for the new light.
+    /// \param position Initial world position for the light.
+    /// \return True if successful.
+    virtual bool createAreaLight(
+        AreaLightType type, PXR_NS::SdfPath const& path, PXR_NS::GfVec3d const& position);
+
+    /// \brief Updates an arbitrary attribute on a prim.
+    /// \param primPath Path to the prim.
+    /// \param attrName Attribute token (e.g., TfToken("inputs:width")).
+    /// \param value New attribute value.
+    /// \return True if successful.
+    virtual bool updatePrimAttribute(PXR_NS::SdfPath const& primPath,
+        PXR_NS::TfToken const& attrName, PXR_NS::VtValue const& value);
+
+    /// \brief Reads the current value of an attribute on a prim.
+    /// Symmetric counterpart to updatePrimAttribute, used by UI to seed
+    /// widget state from the actual prim values (e.g. show the correct
+    /// shadow toggle / radius / intensity for a UsdLux light loaded from
+    /// a USD file). Returns false (and leaves outValue untouched) when
+    /// the prim or attribute doesn't exist or is not authored.
+    /// \param primPath Path to the prim.
+    /// \param attrName Attribute token.
+    /// \param outValue Receives the current value on success.
+    /// \return True if a value was successfully read.
+    virtual bool getPrimAttribute(PXR_NS::SdfPath const& primPath,
+        PXR_NS::TfToken const& attrName, PXR_NS::VtValue& outValue) const;
+
+    /// \brief Returns all area light prims in the scene with their type.
+    /// \param outInfos Populated with the path and type of each discovered
+    ///                 area light prim.
+    virtual void enumerateAreaLights(std::vector<AreaLightInfo>& outInfos) const;
 
     virtual void setRefineLevelFallback(int refineLevelFallback)
     {

--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -203,7 +203,7 @@ public:
 
     /// Bundles the prim path of an area light with its concrete type so
     /// callers (e.g. UI) can present type-specific controls without
-    /// re-querying the underlying scene. Returned by enumerateAreaLights.
+    /// re-querying the underlying scene. Populated by getAreaLight.
     struct AreaLightInfo
     {
         PXR_NS::SdfPath path;
@@ -239,10 +239,26 @@ public:
     virtual bool getPrimAttribute(PXR_NS::SdfPath const& primPath,
         PXR_NS::TfToken const& attrName, PXR_NS::VtValue& outValue) const;
 
-    /// \brief Returns all area light prims in the scene with their type.
-    /// \param outInfos Populated with the path and type of each discovered
-    ///                 area light prim.
-    virtual void enumerateAreaLights(std::vector<AreaLightInfo>& outInfos) const;
+    /// \brief Returns the number of area light prims currently in the
+    ///        scene.
+    /// Split from getAreaLight so callers that only need a count (e.g.
+    /// "are there any?" / "do we need to show the panel?") don't have to
+    /// pay for materializing the full list of paths and types. Indices
+    /// passed to getAreaLight are valid in the range [0, count).
+    /// \return Number of area light prims, or 0 when none / no scene.
+    virtual int getAreaLightCount() const;
+
+    /// \brief Retrieves the i-th area light's path and concrete type.
+    /// Symmetric counterpart to getAreaLightCount; callers that need the
+    /// full list iterate from 0 to getAreaLightCount() - 1. The traversal
+    /// order is determined by the data source and is required only to be
+    /// stable for the duration of a single sequence of calls (no scene
+    /// mutation between calls).
+    /// \param index Zero-based index into the area light set.
+    /// \param outInfo Receives the path and type on success; left
+    ///                untouched on failure.
+    /// \return True when index is in range and outInfo was populated.
+    virtual bool getAreaLight(int index, AreaLightInfo& outInfo) const;
 
     virtual void setRefineLevelFallback(int refineLevelFallback)
     {

--- a/source/dataSource/dataSource.cpp
+++ b/source/dataSource/dataSource.cpp
@@ -111,8 +111,14 @@ bool SceneDataSource::getPrimAttribute(
     return false;
 }
 
-void SceneDataSource::enumerateAreaLights(std::vector<AreaLightInfo>& /*outInfos*/) const
+int SceneDataSource::getAreaLightCount() const
 {
+    return 0;
+}
+
+bool SceneDataSource::getAreaLight(int /*index*/, AreaLightInfo& /*outInfo*/) const
+{
+    return false;
 }
 
 } // namespace HVT_NS

--- a/source/dataSource/dataSource.cpp
+++ b/source/dataSource/dataSource.cpp
@@ -93,4 +93,26 @@ bool SceneDataSource::transformPrimitives(
     return false;
 }
 
+bool SceneDataSource::createAreaLight(
+    AreaLightType /*type*/, const SdfPath& /*path*/, const GfVec3d& /*position*/)
+{
+    return false;
+}
+
+bool SceneDataSource::updatePrimAttribute(
+    const SdfPath& /*primPath*/, const TfToken& /*attrName*/, const VtValue& /*value*/)
+{
+    return false;
+}
+
+bool SceneDataSource::getPrimAttribute(
+    const SdfPath& /*primPath*/, const TfToken& /*attrName*/, VtValue& /*outValue*/) const
+{
+    return false;
+}
+
+void SceneDataSource::enumerateAreaLights(std::vector<AreaLightInfo>& /*outInfos*/) const
+{
+}
+
 } // namespace HVT_NS

--- a/source/dataSource/dataSource.cpp
+++ b/source/dataSource/dataSource.cpp
@@ -111,12 +111,12 @@ bool SceneDataSource::getPrimAttribute(
     return false;
 }
 
-int SceneDataSource::getAreaLightCount() const
+size_t SceneDataSource::getAreaLightCount() const
 {
     return 0;
 }
 
-bool SceneDataSource::getAreaLight(int /*index*/, AreaLightInfo& /*outInfo*/) const
+bool SceneDataSource::getAreaLight(size_t /*index*/, AreaLightInfo& /*outInfo*/) const
 {
     return false;
 }


### PR DESCRIPTION
## Description

Add AreaLightEditing feature flag, AreaLightType / AreaLightInfo types, and four new no-op-by-default virtuals on hvt::SceneDataSource (createAreaLight, updatePrimAttribute, getPrimAttribute, enumerateAreaLights) so concrete data sources can expose USD-stage area-light editing through a uniform interface.

### Changes Made

SupportedFeatures enum — new flag AreaLightEditing = 0x04 so a data source can advertise that it handles the new methods. Backward compatible with existing flags (PrimitiveTransformations, PrimitiveDeletion).

AreaLightType enum — Rect, Disk, Sphere, Cylinder. The four UsdLux area-light types we visualise / edit.

AreaLightInfo struct — { SdfPath path, AreaLightType type }. Returned by enumerateAreaLights so UI can pick type-specific controls (Width/Height vs Radius vs Length) without re-querying or string-matching prim names. This is the piece that fixed the LightEditor showing "Area Light" instead of "Sphere Light" for USD-loaded lights.

Four new virtuals:

`bool createAreaLight(AreaLightType, SdfPath const&, GfVec3d const&)` — author a new area-light prim of the given type at a given world position.

`bool updatePrimAttribute(SdfPath const&, TfToken const& attrName, VtValue const& value)` — set an arbitrary attribute (e.g. inputs:radius, inputs:shadow:enable). Concrete data sources are expected to lazily create the attribute when missing so the same call can drive both schema and non-schema attributes.

`bool getPrimAttribute(SdfPath const&, TfToken const& attrName, VtValue& outValue) const `— symmetric read-back. Returns false when the attribute is absent / unauthored. This is the read-side getter the LightEditor uses to seed widget state from the actual prim values, so loaded USD lights show their real radius/intensity/shadow toggle instead of stale UI defaults.

`void enumerateAreaLights(std::vector<AreaLightInfo>& outInfos) const` — discover every area light in the scene with its concrete type.

## Testing

Unit tests.

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 -->
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: <!-- e.g., v24.08 -->

### Tests Performed
<!-- Check all that apply -->
- [X] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [X] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [X] Code is self-documenting / well-commented
- [X] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [ X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [ X] My code follows the project's coding standards
- [ X] My changes generate no new warnings or errors
