### PR TITLE
Hot Fix - Disable arbitrary failing utest

### DIFF
--- a/test/howTos/howTo08_UseBoundingBoxSceneIndex.cpp
+++ b/test/howTos/howTo08_UseBoundingBoxSceneIndex.cpp
@@ -41,6 +41,12 @@ HVT_TEST(howTo, DISABLED_useBoundingBoxSceneIndexFilter)
 HVT_TEST(howTo, useBoundingBoxSceneIndexFilter)
 #endif
 {
+    if (GetParam() == HgiTokens->Vulkan)
+    {
+        // Vulkan backend render arbitrary fails.
+        GTEST_SKIP() << "Skipping test for the Vulkan backend.";
+    }
+
     // This unit test demonstrates how to add a scene index filter to draw a bounding box using
     // a custom BoundingBoxSceneIndex filter.
 

--- a/test/tests/testComposeTask.cpp
+++ b/test/tests/testComposeTask.cpp
@@ -353,6 +353,12 @@ HVT_TEST(TestViewportToolbox, DISABLED_compose_ComposeTask3)
 HVT_TEST(TestViewportToolbox, compose_ComposeTask3)
 #endif
 {
+    if (GetParam() == HgiTokens->Vulkan)
+    {
+        // Vulkan backend render arbitrary fails.
+        GTEST_SKIP() << "Skipping test for the Vulkan backend.";
+    }
+
     // This unit test performs the same validation than the 'Compose_ComposeTask2' unit test but the
     // first frame pass displays the model and the second one display the bounding box for the
     // model.


### PR DESCRIPTION
## Description

The pull request disables a unit test arbitrary failing on Windows with the Vulkan backend.

### Tests Performed

- [X] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [X] Tested on multiple platforms
- [X] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

- [X] Code is self-documenting / well-commented
- [X] Public API changes are documented with Doxygen comments

## Checklist

- [X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [X] My code follows the project's coding standards
- [X] My changes generate no new warnings or errors
