### PR TITLE
Silence pageableBufferManager warnings

### DIFF
--- a/include/hvt/pageableBuffer/pageableBufferManager.h
+++ b/include/hvt/pageableBuffer/pageableBufferManager.h
@@ -35,9 +35,23 @@
 #include <thread>
 #include <vector>
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/task_arena.h>
 #include <tbb/task_group.h>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 namespace HVT_NS
 {
@@ -540,8 +554,14 @@ size_t HdPageableBufferManager<PagingStrategyType, BufferSelectionStrategyType, 
     KeyHash>::GetBufferCount() const
 {
 #ifdef _DEBUG
-    const size_t nonEmptyBuffer = std::count_if(mBuffers.begin(), mBuffers.end(),
-        [](const auto& buffer) { return buffer.second != nullptr; });
+    size_t nonEmptyBuffer = 0;
+    for (auto const& buffer : mBuffers)
+    {
+        if (buffer.second != nullptr)
+        {
+            ++nonEmptyBuffer;
+        }
+    }
     if (nonEmptyBuffer != mBuffers.size())
     {
         PXR_NAMESPACE_USING_DIRECTIVE


### PR DESCRIPTION
## Description

Silence warning related to the use of the deprecated std::iterator in files under pageableBuffer.

### Changes Made

Silence warnings coming from the tbb includes.

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 -->
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: <!-- e.g., v24.08 -->

### Tests Performed
<!-- Check all that apply -->
- [ ] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [ ] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [ ] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [ ] My code follows the project's coding standards
- [ ] My changes generate no new warnings or errors
