### PR TITLE
AGP-456 - Fix default paths for wasm

### DIFF
--- a/source/utils/pathUtils.cpp
+++ b/source/utils/pathUtils.cpp
@@ -58,6 +58,11 @@ namespace
 
 std::string CleanPath(std::string const& path)
 {
+    if (path.empty() || path == "/")
+    {
+        return path;
+    }
+
     const auto clean = std::filesystem::absolute(path);
     return std::filesystem::canonical(clean).string();
 }
@@ -82,6 +87,9 @@ std::string GetExecutable()
         uint32_t size = EXE_PATH_SIZE;
         _NSGetExecutablePath(path, &size);
         exe = path;
+#elif defined(__EMSCRIPTEN__)
+        // No native executable on WASM.
+        exe = "/";
 #elif defined(__linux)
         char path[EXE_PATH_SIZE] = "";
         // Linux read process exe.
@@ -122,14 +130,19 @@ std::filesystem::path GetDefaultResourceDirectory()
 #elif defined(__ANDROID__)
     const char* localAppPath = std::getenv("LOCAL_APP_PATH");
     std::filesystem::path assetsPath = localAppPath ? localAppPath : "";
-    return assetsPath.append(
-        "Resources"); // TODO: OGSMOD-7219
-                      // Standardize usage of lowercase "resource" folder (gizmos/assets).
+    // TODO: OGSMOD-7219 Standardize usage of lowercase "resource" folder (gizmos/assets).
+    return assetsPath.append("Resources");
+#elif defined(__EMSCRIPTEN__)
+    // WASM has no native executable directory. By convention, application
+    // resources are mounted in the Emscripten virtual filesystem at /Resources/
+    // via `--preload-file <src>@/Resources/...` link options. Callers that need
+    // a different layout must use SetResourceDirectory() before any
+    // Get*Path() call.
+    return std::filesystem::path("/Resources");
 #else
     std::filesystem::path exePath = GetCurrentProcessDirectory();
-    return exePath.append(
-        "Resources"); // TODO: OGSMOD-7219
-                      // Standardize usage of lowercase "resource" folder (gizmos/assets).
+    // TODO: OGSMOD-7219 Standardize usage of lowercase "resource" folder (gizmos/assets).
+    return exePath.append("Resources");
 #endif
 }
 

--- a/source/utils/pathUtils.cpp
+++ b/source/utils/pathUtils.cpp
@@ -58,6 +58,9 @@ namespace
 
 std::string CleanPath(std::string const& path)
 {
+    // Bypass canonicalisation for inputs that std::filesystem::canonical
+    // either can't resolve (empty path) or that would round-trip to themselves
+    // anyway (filesystem root).
     if (path.empty() || path == "/")
     {
         return path;
@@ -115,6 +118,9 @@ std::string GetExecutable()
     return std::filesystem::path(exePath).parent_path();
 }
 
+// TODO: OGSMOD-7219 Standardize usage of lowercase "resource" folder (gizmos/assets).
+[[maybe_unused]] constexpr const char* kResourceSubdir = "Resources";
+
 } // anonymous namespace
 
 std::filesystem::path GetDefaultResourceDirectory()
@@ -128,7 +134,7 @@ std::filesystem::path GetDefaultResourceDirectory()
     return std::filesystem::path([resourcePath UTF8String]);
 #endif
 #elif defined(__ANDROID__)
-    const char* localAppPath = std::getenv("LOCAL_APP_PATH");
+    const char* localAppPath         = std::getenv("LOCAL_APP_PATH");
     std::filesystem::path assetsPath = localAppPath ? localAppPath : "";
     // TODO: OGSMOD-7219 Standardize usage of lowercase "resource" folder (gizmos/assets).
     return assetsPath.append("Resources");
@@ -138,11 +144,9 @@ std::filesystem::path GetDefaultResourceDirectory()
     // via `--preload-file <src>@/Resources/...` link options. Callers that need
     // a different layout must use SetResourceDirectory() before any
     // Get*Path() call.
-    return std::filesystem::path("/Resources");
+    return std::filesystem::path("/") / kResourceSubdir;
 #else
-    std::filesystem::path exePath = GetCurrentProcessDirectory();
-    // TODO: OGSMOD-7219 Standardize usage of lowercase "resource" folder (gizmos/assets).
-    return exePath.append("Resources");
+    return GetCurrentProcessDirectory().append(kResourceSubdir);
 #endif
 }
 
@@ -153,7 +157,7 @@ std::filesystem::path GetDefaultMaterialXDirectory()
     // same folder as the executable.
     // For iOS, Frameworks is under the root of bundle, like "Application Bundle/Frameworks"
 #if defined(__APPLE__)
-    NSBundle* bundle = [NSBundle mainBundle];
+    NSBundle* bundle       = [NSBundle mainBundle];
     NSString* resourcePath = [bundle resourcePath];
 #if !TARGET_OS_IPHONE
     resourcePath = [resourcePath stringByDeletingLastPathComponent];

--- a/test/tests/testPathUtils.cpp
+++ b/test/tests/testPathUtils.cpp
@@ -90,12 +90,13 @@ TEST(TestPathUtils, EmscriptenDefaultResourceDirectory)
 
 TEST(TestPathUtils, EmscriptenDefaultIsCwdIndependent)
 {
+    // Preserve the current path.
     struct CwdGuard
     {
         CwdGuard() { currentPath = std::filesystem::current_path(); }
         ~CwdGuard() { std::filesystem::current_path(currentPath); }
         std::filesystem::path currentPath;
-    } gaurd;
+    } guard;
 
     // Verify the default resource directory does not change when cwd changes.
     hvt::SetResourceDirectory({});
@@ -103,9 +104,11 @@ TEST(TestPathUtils, EmscriptenDefaultIsCwdIndependent)
 
     std::filesystem::current_path("/tmp");
     hvt::SetResourceDirectory({});
-    const auto after = hvt::GetResourceDirectory();
 
+    const auto after = hvt::GetResourceDirectory();
     EXPECT_EQ(before, after);
+
+    // Must remain the same whatever is the current path.
     EXPECT_EQ(after, std::filesystem::path("/Resources"));
 }
 

--- a/test/tests/testPathUtils.cpp
+++ b/test/tests/testPathUtils.cpp
@@ -71,3 +71,29 @@ TEST(TestPathUtils, GetShaderPath_AppendsCorrectly)
 
     hvt::SetResourceDirectory(saved);
 }
+
+#if defined(__EMSCRIPTEN__)
+
+TEST(TestPathUtils, EmscriptenDefaultResourceDirectory)
+{
+    // SetResourceDirectory has been called by other tests; 
+    // always reset to default.
+    hvt::SetResourceDirectory({});
+    EXPECT_EQ(hvt::GetResourceDirectory(), std::filesystem::path("/Resources"));
+}
+
+TEST(TestPathUtils, EmscriptenDefaultIsCwdIndependent)
+{
+    // Verify the default resource directory does not change when cwd changes.
+    hvt::SetResourceDirectory({});
+    const auto before = hvt::GetResourceDirectory();
+
+    std::filesystem::current_path("/tmp");
+    hvt::SetResourceDirectory({});
+    const auto after = hvt::GetResourceDirectory();
+
+    EXPECT_EQ(before, after);
+    EXPECT_EQ(after, std::filesystem::path("/Resources"));
+}
+
+#endif

--- a/test/tests/testPathUtils.cpp
+++ b/test/tests/testPathUtils.cpp
@@ -72,18 +72,31 @@ TEST(TestPathUtils, GetShaderPath_AppendsCorrectly)
     hvt::SetResourceDirectory(saved);
 }
 
-#if defined(__EMSCRIPTEN__)
-
 TEST(TestPathUtils, EmscriptenDefaultResourceDirectory)
 {
-    // SetResourceDirectory has been called by other tests; 
-    // always reset to default.
+    // SetResourceDirectory has been called by other tests; always reset to default.
     hvt::SetResourceDirectory({});
-    EXPECT_EQ(hvt::GetResourceDirectory(), std::filesystem::path("/Resources"));
+
+    // Whatever is the platform, the returned path must always be an absolute path.
+    const auto& dir = hvt::GetResourceDirectory();
+    EXPECT_TRUE(dir.is_absolute());
+
+#if defined(__EMSCRIPTEN__)
+    EXPECT_EQ(dir, std::filesystem::path("/Resources"));
+#endif
 }
+
+#if defined(__EMSCRIPTEN__)
 
 TEST(TestPathUtils, EmscriptenDefaultIsCwdIndependent)
 {
+    struct CwdGuard
+    {
+        CwdGuard() { currentPath = std::filesystem::current_path(); }
+        ~CwdGuard() { std::filesystem::current_path(currentPath); }
+        std::filesystem::path currentPath;
+    } gaurd;
+
     // Verify the default resource directory does not change when cwd changes.
     hvt::SetResourceDirectory({});
     const auto before = hvt::GetResourceDirectory();


### PR DESCRIPTION
## Description

The pull request fixes the default path for wasm.

### Tests Performed
- [X] Existing unit tests pass
- [X] Added/Updated unit test(s) for the changes
- [X] Tested on multiple platforms
- [x] Tested with different render delegates
- [x] Performance testing (if applicable)

## Documentation

- [X] Code is self-documenting / well-commented
- [X] Public API changes are documented with Doxygen comments

## Checklist

- [X] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [X] My code follows the project's coding standards
- [X] My changes generate no new warnings or errors
