### PR TITLE
AGPHVT-121 : support compilation on usd 24.11 and 25.05

### DIFF
--- a/include/hvt/pageableBuffer/pageableBuffer.h
+++ b/include/hvt/pageableBuffer/pageableBuffer.h
@@ -44,7 +44,7 @@ template <
     >
 class HdPageableBufferManager;
 
-enum class HVT_API HdBufferState
+enum class HdBufferState
 {
     Unknown        = 0,      ///< Initial state
     SceneBuffer    = 1 << 0, ///< Data in the scene
@@ -52,7 +52,7 @@ enum class HVT_API HdBufferState
     DiskBuffer     = 1 << 2, ///< Data in disk
 };
 
-enum class HVT_API HdBufferUsage
+enum class HdBufferUsage
 {
     Static, ///< Immutable data, will be paged if possible
     Dynamic ///< Mutable data, will be paged if necessary

--- a/include/hvt/pageableBuffer/pageableDataSource.h
+++ b/include/hvt/pageableBuffer/pageableDataSource.h
@@ -52,7 +52,7 @@ struct HvtDebugCounter
 #endif
 
 // Paging status types for metrics/observability
-enum class HVT_API HdPagingStatus
+enum class HdPagingStatus
 {
     Resident,  ///< Data is in memory and immediately available
     PagedOut,  ///< Data has been paged out to disk

--- a/source/engine/engine.cpp
+++ b/source/engine/engine.cpp
@@ -31,6 +31,9 @@
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/tokens.h>
+#if PXR_VERSION < 2511
+#include <pxr/imaging/hdx/task.h>
+#endif
 
 // clang-format off
 #if defined(__clang__)
@@ -226,10 +229,24 @@ bool Engine::AreTasksConverged(HdRenderIndex* const index, SdfPathVector const& 
                 "No task at %s in render index in Engine::AreTasksConverged()", taskPath.GetText());
             continue;
         }
+#if PXR_VERSION >= 2511
         if (!task->IsConverged())
         {
             return false;
         }
+#else
+        // HdTask::IsConverged() was added in USD 25.11. On older versions, only
+        // progressive HdxTask subclasses report convergence; other tasks are
+        // treated as converged (matching the HdTask default in newer USD).
+        if (std::shared_ptr<HdxTask> const hdxTask =
+                std::dynamic_pointer_cast<HdxTask>(task))
+        {
+            if (!hdxTask->IsConverged())
+            {
+                return false;
+            }
+        }
+#endif
     }
 
     return true;


### PR DESCRIPTION
## Description

Support compilation of HVT with usd 24.11 and 25.05 and support Clang compiler on Windows

### Changes Made

- Fixed the Engine::AreTasksConverged method
- Fix the HVT_API not needed on enums (was not compiling with Clang on Windows)

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 -->
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: v25.05

### Tests Performed
<!-- Check all that apply -->
- [ ] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [ ] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [ ] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [ ] My code follows the project's coding standards
- [ ] My changes generate no new warnings or errors
