### PR TITLE
Update USD to 26.05

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 # Declare the project.
 project(HydraViewportToolbox
-    VERSION      0.26.03.0
+    VERSION      0.26.05.0
     DESCRIPTION  "Utilities to support graphics viewports using OpenUSD Hydra"
     LANGUAGES    CXX
     HOMEPAGE_URL https://github.com/Autodesk/hydra-viewport-toolbox

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -54,7 +54,7 @@
   "overrides": [
     {
       "name": "usd",
-      "version": "26.3"
+      "version": "26.5"
     },
     {
       "name": "gtest",
@@ -69,7 +69,7 @@
       "version": "1.9.5"
     }
   ],
-  "builtin-baseline": "58950f88544e4637524dbd6a01d0317cf4cb77fc",
+  "builtin-baseline": "d592849579fb1fb22f87406b2184522ea21a8783",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Autodesk/hydra-viewport-toolbox"
 }


### PR DESCRIPTION
## Description

Update USD to version 26.05
See: https://github.com/PixarAnimationStudios/OpenUSD/tree/v26.05

### Changes Made

- Update vcpkg submodule
- Update vcpkg USD version to 26.05
- Update HVT version to 0.26.05.0

## Testing

Tested from an external project CI/CD

### Test Configuration
- **Platform(s) tested**: Windows 11, Linux, MacOS
- **Build configuration(s)**: Debug, Release, RelWithDebInfo
- **Render delegate(s)**: Storm (OpenGL), Storm (Metal)
- **OpenUSD version**: v26.05

### Tests Performed
<!-- Check all that apply -->
- [x] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [x] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

- [x] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments

## Checklist

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
