### PR TITLE
[NOM-5453] Allocate fresh depth buffer when pass's sample count differs from the chained input

### DIFF
--- a/source/engine/renderBufferManager.cpp
+++ b/source/engine/renderBufferManager.cpp
@@ -668,7 +668,14 @@ bool RenderBufferManager::Impl::SetRenderOutputs(TfToken const& outputToVisualiz
                     depthDesc  = desc;
                     depthInput = input;
 
-                    if (inputFound)
+                    // Reuse the previous pass's depth buffer unless its multisample state
+                    // mismatches this pass. An MSAA overlay pass chained after a resolved
+                    // single-sampled pass would otherwise inherit single-sampled depth, which
+                    // cannot be attached alongside a multisampled color target.
+                    const bool depthMultisampleMismatch =
+                        input.buffer && (input.buffer->IsMultiSampled() != desc.multiSampled);
+
+                    if (inputFound && !depthMultisampleMismatch)
                     {
                         // If the renderer remains the same, we don't want to copy the depth buffer.
                         // The existing depth buffer will continue to be used.
@@ -684,6 +691,19 @@ bool RenderBufferManager::Impl::SetRenderOutputs(TfToken const& outputToVisualiz
                         // accuracy.
                         depthInput.texture = HgiTextureHandle();
                     }
+                    else if (inputFound)
+                    {
+                        // Same renderer but the chained depth's sample count differs from this
+                        // pass, so it cannot be reused directly. Allocate a fresh depth buffer at
+                        // this pass's sample count. The old contents are not copied in: an MSAA
+                        // overlay (the case this handles) clears its depth before drawing, and a
+                        // resolved single-sampled depth has no meaningful per-sample copy into a
+                        // multisampled target anyway.
+                        inputFound         = false;
+                        depthInput.texture = HgiTextureHandle();
+                    }
+                    // else: different renderer - leave depthInput.texture intact so the depth is
+                    // copied into the fresh buffer by _PrepareBuffersFromInputs, exactly as before.
                 }
                 else if (!colorInput.texture)
                 {

--- a/source/engine/renderBufferManager.cpp
+++ b/source/engine/renderBufferManager.cpp
@@ -662,20 +662,21 @@ bool RenderBufferManager::Impl::SetRenderOutputs(TfToken const& outputToVisualiz
         {
             if (input.aovName == localOutputs[i])
             {
-                inputFound = (rendererName == input.rendererName);
+                // Reuse the previous pass's buffer only when it has the same multisample state as
+                // this pass. An MSAA pass chained after a resolved single-sampled pass would
+                // otherwise inherit a single-sampled buffer, which cannot be attached alongside a
+                // multisampled target. On a mismatch treat the input as not found so a fresh
+                // buffer is allocated.
+                const bool multisampleMismatch =
+                    input.buffer && (input.buffer->IsMultiSampled() != desc.multiSampled);
+                inputFound = (rendererName == input.rendererName) && !multisampleMismatch;
+
                 if (localOutputs[i] == PXR_NS::HdAovTokens->depth)
                 {
                     depthDesc  = desc;
                     depthInput = input;
 
-                    // Reuse the previous pass's depth buffer unless its multisample state
-                    // mismatches this pass. An MSAA overlay pass chained after a resolved
-                    // single-sampled pass would otherwise inherit single-sampled depth, which
-                    // cannot be attached alongside a multisampled color target.
-                    const bool depthMultisampleMismatch =
-                        input.buffer && (input.buffer->IsMultiSampled() != desc.multiSampled);
-
-                    if (inputFound && !depthMultisampleMismatch)
+                    if (inputFound)
                     {
                         // If the renderer remains the same, we don't want to copy the depth buffer.
                         // The existing depth buffer will continue to be used.
@@ -691,19 +692,6 @@ bool RenderBufferManager::Impl::SetRenderOutputs(TfToken const& outputToVisualiz
                         // accuracy.
                         depthInput.texture = HgiTextureHandle();
                     }
-                    else if (inputFound)
-                    {
-                        // Same renderer but the chained depth's sample count differs from this
-                        // pass, so it cannot be reused directly. Allocate a fresh depth buffer at
-                        // this pass's sample count. The old contents are not copied in: an MSAA
-                        // overlay (the case this handles) clears its depth before drawing, and a
-                        // resolved single-sampled depth has no meaningful per-sample copy into a
-                        // multisampled target anyway.
-                        inputFound         = false;
-                        depthInput.texture = HgiTextureHandle();
-                    }
-                    // else: different renderer - leave depthInput.texture intact so the depth is
-                    // copied into the fresh buffer by _PrepareBuffersFromInputs, exactly as before.
                 }
                 else if (!colorInput.texture)
                 {


### PR DESCRIPTION
## Description

RenderBufferManager::SetRenderOutputs reuses the previous pass's buffer when the renderer is unchanged, in order to preserve sub-pixel information. That reuse assumed the chained buffer always has the same multisample state as the pass consuming it.

This is not true when a pass's sample count differs from the pass before it. A multisampled overlay pass chained after a resolved, single-sampled pass would inherit the single-sampled buffer. A single-sampled buffer attachment cannot be bound alongside a multisampled color target, so the overlay silently loses multisampling (or fails validation, depending on backend).

This PR makes buffer reuse conditional on a matching sample count. On a same-renderer sample-count mismatch, a fresh buffer is allocated at the pass's own sample count instead of reusing the mismatched one. The matching-sample-count and different-renderer paths are left unchanged.

### Changes Made

- Fold a multisample-state check into the `inputFound` predicate, so it applies uniformly to every AOV (color and depth) rather than being special-cased for depth.
- Only reuse the chained buffer when input.buffer->IsMultiSampled() matches the pass's multiSampled descriptor.
- On a same-renderer mismatch, force allocation of a fresh buffer at the pass's sample count and skip the copy (the resolved single-sampled buffer has no meaningful per-sample copy into a multisampled target, and overlay passes clear their buffers before drawing).
- Leave the different-renderer path untouched, so existing configurations behave exactly as before..
 
## Testing

Verified with a multisampled overlay pass (4x MSAA) chained after a resolved, single-sampled pass. Before the change the overlay inherited single-sampled buffer and could not enable MSAA; after the change it receives a correctly multisampled buffer and renders antialiased. Confirmed the single-sampled (non-MSAA) path and the existing cross-renderer copy path are unaffected.

### Test Configuration
- **Platform(s) tested**: macOS (Metal)
- **Build configuration(s)**: Release
- **Render delegate(s)**: Storm (Metal)
- **OpenUSD version**: 26.05

### Tests Performed
<!-- Check all that apply -->
- [x] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [x] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [x] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [ ] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
