### PR TITLE
Fix USD version check on SubmitLayoutChange

### DIFF
--- a/source/tasks/visualizeAovTask.cpp
+++ b/source/tasks/visualizeAovTask.cpp
@@ -665,8 +665,8 @@ void VisualizeAovTask::Execute(HdTaskContext* ctx)
 
     // Transition from color target layout to shader read layout.
     // HgiTexture::SubmitLayoutChange only started returning the previous layout (so it can be
-    // restored afterwards) in USD >= 25.05 (commit af06919d66); before that it returns void.
-#if PXR_VERSION >= 2505
+    // restored afterwards) in USD >= 25.08; before that it returns void.
+#if PXR_VERSION >= 2508
     const auto oldLayout = aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
 #else
     aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
@@ -696,7 +696,7 @@ void VisualizeAovTask::Execute(HdTaskContext* ctx)
         if (!minMaxTexture)
         {
             TF_WARN("Failed to compute min/max depth texture");
-#if PXR_VERSION >= 2505
+#if PXR_VERSION >= 2508
             aovTexture->SubmitLayoutChange(oldLayout);
 #endif
             return;
@@ -733,7 +733,7 @@ void VisualizeAovTask::Execute(HdTaskContext* ctx)
     _ApplyVisualizationKernel(outputTexture, minMaxTexture);
 
     // Restore the original color target layout
-#if PXR_VERSION >= 2505
+#if PXR_VERSION >= 2508
     aovTexture->SubmitLayoutChange(oldLayout);
 #endif
 

--- a/source/tasks/wboitResolveTask.cpp
+++ b/source/tasks/wboitResolveTask.cpp
@@ -126,8 +126,8 @@ void WbOitResolveTask::Execute(HdTaskContext* ctx)
     }
 
     // HgiTexture::SubmitLayoutChange only started returning the previous layout (so it can be
-    // restored afterwards) in USD >= 25.05 (commit af06919d66); before that it returns void.
-#if PXR_VERSION >= 2505
+    // restored afterwards) in USD >= 25.08; before that it returns void.
+#if PXR_VERSION >= 2508
     const auto oldLayout0 = buffer0->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
     const auto oldLayout1 = buffer1->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
 #else
@@ -143,7 +143,7 @@ void WbOitResolveTask::Execute(HdTaskContext* ctx)
 
     _shader->Draw(aovTexture, {});
 
-#if PXR_VERSION >= 2505
+#if PXR_VERSION >= 2508
     buffer0->SubmitLayoutChange(oldLayout0);
     buffer1->SubmitLayoutChange(oldLayout1);
 #endif


### PR DESCRIPTION
## Description

Fix USD version check on SubmitLayoutChange

### Changes Made

Code was previously checking for USD >= 25.05, but the right check is >= 25.08

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 --> Windows, Mac, Linux
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->RelWithDebInfo, Debug
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->Storm, PRman
- **OpenUSD version**: <!-- e.g., v24.08 -->24.11, 25.05, 25.08, 25.11, 26.05

### Tests Performed
<!-- Check all that apply -->
- [x] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [x] Tested on multiple platforms
- [x] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
