### PR TITLE
Fix USD <= 25.05 bug with camera dirtying on resyncs

### DIFF
--- a/source/engine/si/framePassSICamera.cpp
+++ b/source/engine/si/framePassSICamera.cpp
@@ -30,6 +30,7 @@
 
 #include <pxr/base/gf/camera.h>
 #include <pxr/imaging/hd/cameraSchema.h>
+#include <pxr/imaging/hd/dataSourceLocator.h>
 #include <pxr/imaging/hd/retainedDataSource.h>
 #include <pxr/imaging/hd/retainedSceneIndex.h>
 #include <pxr/imaging/hd/tokens.h>
@@ -245,6 +246,20 @@ void FramePassSICamera::Update(ViewParams const& viewInfo)
         _retainedSceneIndex->AddPrims({ { _cameraId, HdPrimTypeTokens->camera,
             BuildCameraPrimDataSource(
                 newCamera, newWorldXform, clipPlanes, viewInfo.linearExposureScale) } });
+
+#if PXR_VERSION <= 2505
+        // The above AddPrims sends PrimsAdded which is handled as a resync (as intended).
+        // The HdSceneIndexAdapterSceneDelegate resyncs prims by converting an empty
+        // HdDataSourceLocator to dirty bits, and dirtying the prims in the render index
+        // with those dirty bits. However, there is a bug in USD <= 25.05 where 
+        // HdDirtyBitsTranslator::SprimLocatorSetToDirtyBits() does not handle the empty
+        // locator properly and will miss the DirtyTransform bit. So we need to send an
+        // extra dirty notification for the transform to also be updated. This was fixed
+        // in later USD versions by commit d98a9595fe16c5ba1acd7fa449a036568ad31290.
+        HdDataSourceLocatorSet dirtyLocators;
+        dirtyLocators.insert(HdXformSchema::GetDefaultLocator());
+        _retainedSceneIndex->DirtyPrims({ { _cameraId, dirtyLocators } });
+#endif
     }
 }
 


### PR DESCRIPTION
## Description

There was a bug in USD <= 25.05 where camera dirtying on resyncs through PrimsAdded was missing the DirtyTransform bit, which meant that some updates to cameras were lost in translation. This was later fixed by https://github.com/PixarAnimationStudios/OpenUSD/commit/d98a9595fe16c5ba1acd7fa449a036568ad31290, but we still need to work around it for those versions.

### Changes Made

Added an extra transform dirty for earlier USD versions.

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 --> Windows, Linux
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo --> RelWithDebInfo, Debug
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) --> Storm, PRman
- **OpenUSD version**: <!-- e.g., v24.08 -->24.11, 25.05, 25.11, 26.05

### Tests Performed
<!-- Check all that apply -->
- [x] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [x] Tested on multiple platforms
- [x] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
