### PR TITLE
AGP-633: Reuse HGI for faster unit tests (Vulkan and Metal)

### DIFF
--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <pxr/base/gf/frustum.h>
+#include <pxr/base/tf/getenv.h>
 #include <pxr/imaging/hgi/tokens.h>
 
 #if defined(_MSC_VER)
@@ -42,10 +43,12 @@
 #pragma clang diagnostic pop
 #endif
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <unordered_map>
 #include <vector>
 
 namespace
@@ -67,6 +70,49 @@ const std::filesystem::path inAssetsPath = TOSTRING(HVT_TEST_DATA_PATH) + "/data
 const std::filesystem::path resFullpath  = TOSTRING(HVT_RESOURCE_PATH);
 std::filesystem::path inBaselinePath     = TOSTRING(HVT_TEST_DATA_PATH) + "/data/baselines";
 #endif
+
+// Creating a Hgi is expensive: HgiVulkan spins up a VkInstance and VkDevice
+// (with validation layers in Debug builds) and HgiMetal creates an MTLDevice and
+// command queue. Every fresh device also throws away the render delegate's
+// compiled shader and pipeline caches. Since hundreds of parameterized tests
+// each build and tear down their own context, that cost is paid over and over
+// for identical work.
+//
+// A single Hgi instance per backend is therefore created lazily and reused
+// across all test contexts in the process, so the device and its warm
+// shader/pipeline caches survive between tests. Only backends whose device is
+// independent of the per-test window are shared: Vulkan and Metal both create
+// the device up front and attach a throw-away per-test surface/drawable, so the
+// shared device safely outlives each window. OpenGL is intentionally excluded
+// because HgiGL's cached GPU objects live inside the GL context, which is
+// created and destroyed together with each test's window; sharing it would
+// require a process-global GL context (a separate, larger change) and OpenGL
+// context/shader setup is already cheap.
+//
+// Sharing is enabled by default; set HVT_TEST_SHARE_HGI=0 to opt out (e.g. when
+// debugging a test that is sensitive to residual device state).
+
+using SharedHgiCache =
+    std::unordered_map<pxr::TfToken, std::shared_ptr<pxr::Hgi>, pxr::TfToken::HashFunctor>;
+
+SharedHgiCache& sharedHgiCache()
+{
+    static SharedHgiCache cache;
+    return cache;
+}
+
+bool shareHgiEnabled()
+{
+    static const bool enabled = pxr::TfGetenvBool("HVT_TEST_SHARE_HGI", true);
+    return enabled;
+}
+
+// Only backends whose GPU device is independent of the per-test window can be
+// safely shared process-wide (see the note above). OpenGL is excluded.
+bool isShareableBackend(const pxr::TfToken& type)
+{
+    return type == pxr::HgiTokens->Vulkan || type == pxr::HgiTokens->Metal;
+}
 
 } // anonymous namespace
 
@@ -196,7 +242,19 @@ bool HydraRendererContext::compareImages(const std::string& inFile, const std::s
 
 void HydraRendererContext::createHGI([[maybe_unused]] pxr::TfToken type)
 {
-    if (!type.IsEmpty())
+    // Only backends whose device is independent of the per-test window benefit
+    // from (and are safe for) process-wide sharing. The cache is keyed by backend
+    // type so a process that creates multiple backends never borrows the wrong one.
+    const bool canShare = shareHgiEnabled() && isShareableBackend(type);
+    auto& cache         = sharedHgiCache();
+    const auto cached   = canShare ? cache.find(type) : cache.end();
+
+    if (cached != cache.end())
+    {
+        // Co-own the already-created shared instance.
+        _hgi = cached->second;
+    }
+    else if (!type.IsEmpty())
         _hgi = pxr::Hgi::CreateNamedHgi(type);
     else
     {
@@ -215,23 +273,32 @@ void HydraRendererContext::createHGI([[maybe_unused]] pxr::TfToken type)
 
     if (!_hgi->IsBackendSupported())
     {
+        _hgi.reset();
         throw std::runtime_error("HGI initialization succeeded but backend is not supported!");
     }
-    else if (_hgiDriver.driver.IsEmpty())
-    {
-        _hgiDriver.name   = pxr::HgiTokens->renderDriver;
-        _hgiDriver.driver = pxr::VtValue(_hgi.get());
-    }
-    else
-    {
-        throw std::runtime_error("HGI initialization already done!");
-    }
+
+    // Promote a freshly created shareable instance into the process-global cache.
+    if (canShare && cached == cache.end())
+        cache.emplace(type, _hgi);
+
+    // The driver is a per-context view onto the (possibly shared) Hgi; createHGI runs once per
+    // context construction, so it is always initialized here.
+    _hgiDriver.name   = pxr::HgiTokens->renderDriver;
+    _hgiDriver.driver = pxr::VtValue(_hgi.get());
 }
 
 void HydraRendererContext::destroyHGI()
 {
-    _hgi       = nullptr;
+    // A shared instance is co-owned by the process-global cache, so dropping this
+    // context's reference keeps it alive (and warm) for the next test. An unshared
+    // instance is destroyed here, as this reference is the only one.
+    _hgi.reset();
     _hgiDriver = {};
+}
+
+void releaseSharedHgi()
+{
+    sharedHgiCache().clear();
 }
 
 TestView::TestView(std::shared_ptr<HydraRendererContext>& context) : _context(context)

--- a/test/RenderingFramework/TestHelpers.cpp
+++ b/test/RenderingFramework/TestHelpers.cpp
@@ -255,7 +255,9 @@ void HydraRendererContext::createHGI([[maybe_unused]] pxr::TfToken type)
         _hgi = cached->second;
     }
     else if (!type.IsEmpty())
+    {
         _hgi = pxr::Hgi::CreateNamedHgi(type);
+    }
     else
     {
 #if defined(ADSK_OPENUSD_PENDING)
@@ -279,7 +281,9 @@ void HydraRendererContext::createHGI([[maybe_unused]] pxr::TfToken type)
 
     // Promote a freshly created shareable instance into the process-global cache.
     if (canShare && cached == cache.end())
+    {
         cache.emplace(type, _hgi);
+    }
 
     // The driver is a per-context view onto the (possibly shared) Hgi; createHGI runs once per
     // context construction, so it is always initialized here.

--- a/test/RenderingFramework/TestHelpers.h
+++ b/test/RenderingFramework/TestHelpers.h
@@ -101,6 +101,13 @@ std::filesystem::path const& getBaselineFolder();
 /// Gets the path to the HVT public resource directory.
 std::filesystem::path const& getPublicResourceFolder();
 
+/// \brief Destroys the Hgi instances shared between test contexts.
+/// \note Test binaries must call this after RUN_ALL_TESTS() and before tearing down their
+/// windowing system (SDL/GLFW). The shared devices cannot be destroyed by static destructors
+/// because those run after main() returns, i.e. after the windowing system is already gone.
+/// Not calling it is safe but leaks the devices until process exit.
+void releaseSharedHgi();
+
 /// Base class for the OpenGL and Metal context renderers.
 class HydraRendererContext
 {
@@ -153,7 +160,9 @@ public:
     [[nodiscard]] bool saveImage(std::string const& fileName);
 
 protected:
-    pxr::HgiUniquePtr _hgi;
+    /// The Hgi backing this context. Shared instances are co-owned with the process-global
+    /// cache in TestHelpers.cpp, so this is a shared_ptr rather than pxr::HgiUniquePtr.
+    std::shared_ptr<pxr::Hgi> _hgi;
     bool _presentationEnabled = true;
 
     /// The image capture object.

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -46,6 +46,10 @@ int main(int argc, char** argv)
         std::cerr << "Unexpected failure" << std::endl;
     }
 
+    // Must run before SDL_Quit(): the shared devices were created against SDL surfaces,
+    // and static destructors would only run after main() returns.
+    TestHelpers::releaseSharedHgi();
+
     SDL_Quit();
 
     return ret;


### PR DESCRIPTION
## Description

This improves testing time with Vulkan and Metal backends by sharing the HGI instance across tests within a test suite.
This prevent repetitive recompilation of the same shaders, and reduces the total unit test time significantly.

**Before changes:**
TestViewportToolbox: 577.9s

**After changes:**
TestViewportToolbox: 201.8s (186% test speed improvement)

### Changes Made

- Avoid destroying HGI instance at the end of each individual test, only destroy it before ending the test app.

## Testing

- Ran unit tests on Windows

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 -->
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: <!-- e.g., v24.08 -->

### Tests Performed
<!-- Check all that apply -->
- [x] Existing unit tests pass
- [x] Added/Updated unit test(s) for the changes
- [x] Tested on multiple platforms
- [x] Tested with different render delegates
- [x] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
