### PR TITLE
AGP-670 - Fix code-review issues and add regression tests

### DIFF
--- a/include/hvt/dataSource/dataSource.h
+++ b/include/hvt/dataSource/dataSource.h
@@ -207,7 +207,9 @@ public:
     struct AreaLightInfo
     {
         PXR_NS::SdfPath path;
-        AreaLightType   type;
+        // Default-initialized so a caller that reads `type` after a failed getAreaLight()
+        // (which returns false without touching the struct) does not read an indeterminate value.
+        AreaLightType   type = AreaLightType::Rect;
     };
 
     /// \brief Creates a new area light prim of the specified type.

--- a/source/dataSource/dataSourceRegistry.h
+++ b/source/dataSource/dataSourceRegistry.h
@@ -30,7 +30,9 @@ public:
     size_t fileTypesDescCount() const override { return _fileTypesDesc.size(); }
     const FileTypesDesc& getFileTypesDesc(size_t index) const override
     {
-        return _fileTypesDesc[index];
+        // Bounds-checked access: operator[] would be undefined behavior out of range (e.g. a
+        // stale count paired with fileTypesDescCount()); at() throws std::out_of_range instead.
+        return _fileTypesDesc.at(index);
     }
     bool getFileTypesDesc(const std::string& fileType, FileTypesDesc& desc) const override;
     bool isSupportedFileType(const std::string& fileType) const override;

--- a/source/engine/copyDepthShader.cpp
+++ b/source/engine/copyDepthShader.cpp
@@ -82,6 +82,9 @@ bool CopyDepthShader::_CreateShaderProgram(HgiTextureDesc const& inputTextureDes
     if (!vertFn->IsValid())
     {
         TF_CODING_ERROR("%s", vertFn->GetCompileErrors().c_str());
+        // _Cleanup() only frees shader functions owned by _shaderProgram, which does not exist
+        // yet, so destroy this function explicitly to avoid leaking it.
+        _hgi->DestroyShaderFunction(&vertFn);
         _Cleanup();
         return false;
     }
@@ -108,6 +111,10 @@ bool CopyDepthShader::_CreateShaderProgram(HgiTextureDesc const& inputTextureDes
     if (!fragFn->IsValid())
     {
         TF_CODING_ERROR("%s", fragFn->GetCompileErrors().c_str());
+        // Neither function has been moved into a shader program yet, so _Cleanup() cannot free
+        // them; destroy both explicitly to avoid leaking them.
+        _hgi->DestroyShaderFunction(&fragFn);
+        _hgi->DestroyShaderFunction(&vertFn);
         _Cleanup();
         return false;
     }

--- a/source/engine/lightingManager.cpp
+++ b/source/engine/lightingManager.cpp
@@ -161,8 +161,13 @@ void LightingManager::Impl::SetBuiltInLightingState(
                     i, activeLights[i], lightPath, worldExtent, _lightIds, _isHighQualityRenderer);
             }
         }
-        _primBackend->RemoveLightSprim(_lightIds.size() - 1, _lightIds);
-        _lightIds.pop_back();
+        // Remove every excess light, not just one: the active light count can shrink by more
+        // than one in a single call, and leaving stale lights would keep rendering them.
+        while (_lightIds.size() > activeLights.size())
+        {
+            _primBackend->RemoveLightSprim(_lightIds.size() - 1, _lightIds);
+            _lightIds.pop_back();
+        }
     }
 
     // If there has been no change in the number of lights we still may need to

--- a/source/engine/renderBufferManager.cpp
+++ b/source/engine/renderBufferManager.cpp
@@ -308,6 +308,13 @@ void RenderBufferManager::Impl::_PrepareBuffersFromInputs(RenderBufferBinding co
         }
     }
 
+    // The input binding may carry a valid texture but a null backing buffer, so guard the
+    // fallback before dereferencing (mirrors the depth path below).
+    if (!colorBuffer)
+    {
+        return;
+    }
+
     HgiTextureHandle colorOutput;
     VtValue colorOutputValue = colorBuffer->GetResource(desc.multiSampled);
     if (colorOutputValue.IsHolding<HgiTextureHandle>())
@@ -526,6 +533,10 @@ bool RenderBufferManager::Impl::SetRenderOutputs(TfToken const& outputToVisualiz
         }
     }
 
+    // Capture whether the AOV output set actually changed before caching the new value;
+    // the clear decision below depends on the previous-vs-new comparison.
+    const bool outputsChanged = _aovOutputs != outputs;
+
     _aovOutputs = outputs;
 
     // Temporary 2D dimensions to calculate dimensions3 (the 2D version isn't used later).
@@ -549,8 +560,8 @@ bool RenderBufferManager::Impl::SetRenderOutputs(TfToken const& outputToVisualiz
         }
 
         // If progressive rendering is enabled, render buffer clear is only required when
-        // `_aovOutputs != outputs`.
-        bool needClear = !_isProgressiveRenderingEnabled || _aovOutputs != outputs;
+        // the output set actually changed.
+        bool needClear = !_isProgressiveRenderingEnabled || outputsChanged;
 
         // This will delete Bprims from the storage backend and clear the _viewportAov and
         // _aovBufferIds SdfPathVector.

--- a/source/engine/selectionHelper.cpp
+++ b/source/engine/selectionHelper.cpp
@@ -124,6 +124,11 @@ SelectionSettings& SelectionHelper::GetSettings()
 
 void SelectionHelper::SetSelectionContextData(Engine* engine)
 {
+    if (!engine)
+    {
+        return;
+    }
+
     VtValue selectionValue(_selectionTracker);
     engine->SetTaskContextData(HdxTokens->selectionState, selectionValue);
 }

--- a/source/engine/taskManager.cpp
+++ b/source/engine/taskManager.cpp
@@ -190,8 +190,15 @@ const SdfPath& TaskManager::_AddTask(TfToken const& taskName, CommitTaskFn const
         }
     }
 
-    auto it = _tasks.insert((order != InsertionOrder::insertAfter) ? itInsert : ++itInsert,
-        { taskId, fnCommit, true, taskFlags });
+    // For insertAfter, advance past the target position. Guard against incrementing a
+    // past-the-end iterator (e.g. when atPos is empty), which is undefined behavior; in that
+    // case the task is simply appended at the end.
+    if (order == InsertionOrder::insertAfter && itInsert != _tasks.end())
+    {
+        ++itInsert;
+    }
+
+    auto it = _tasks.insert(itInsert, { taskId, fnCommit, true, taskFlags });
 
     return it->uid;
 }
@@ -221,7 +228,12 @@ HdTaskSharedPtrVector TaskManager::CommitTaskValues(TaskFlags taskFlags)
             taskEntry.fnCommit(fnGetValue, fnSetValue);
         }
 
-        enabledTasks.push_back(_renderIndex->GetTask(taskEntry.uid));
+        // The render index may not have a task for this uid (e.g. a backend failed to
+        // instantiate it); skip null tasks so callers never dereference a null HdTaskSharedPtr.
+        if (HdTaskSharedPtr task = _renderIndex->GetTask(taskEntry.uid))
+        {
+            enabledTasks.push_back(task);
+        }
     }
 
     return enabledTasks;
@@ -275,8 +287,13 @@ HdTaskSharedPtrVector const TaskManager::GetTasks(TaskFlags taskFlags) const
             continue;
         }
 
+        // Skip null tasks: the render index may not have a task for this uid, and callers must
+        // never receive a null HdTaskSharedPtr to dereference.
         HdTaskSharedPtr pTask = _renderIndex->GetTask(task.uid);
-        filteredTasks.push_back(pTask);
+        if (pTask)
+        {
+            filteredTasks.push_back(pTask);
+        }
     }
     return filteredTasks;
 }

--- a/source/engine/viewportEngine.cpp
+++ b/source/engine/viewportEngine.cpp
@@ -521,7 +521,11 @@ void CreateGrid(UsdStageRefPtr& stage, SdfPath const& gridPath, GfVec3d const& p
     {
         bool resetStack = true;
         auto xFormOps   = tm.GetOrderedXformOps(&resetStack);
-        xFormOps[0].Set(position);
+        // A pre-existing prim may have no ordered xform ops; indexing [0] would be UB.
+        if (!xFormOps.empty())
+        {
+            xFormOps[0].Set(position);
+        }
     }
 }
 
@@ -766,7 +770,11 @@ void CreateAxisTripod(
     if (tm)
     {
         auto xFormOps = tm.GetOrderedXformOps(&resetStack);
-        xFormOps[0].Set(position);
+        // A pre-existing prim may have no ordered xform ops; indexing [0] would be UB.
+        if (!xFormOps.empty())
+        {
+            xFormOps[0].Set(position);
+        }
     }
 
     // set the scale

--- a/source/geometry/geometry.cpp
+++ b/source/geometry/geometry.cpp
@@ -594,6 +594,14 @@ HdContainerDataSourceHandle Create2DMaterial(
         shaderReg.GetShaderNodeFromSourceCode(source, HioGlslfxTokens->glslfx, NdrTokenMap());
 #endif
 
+    // GetShaderNodeFromSourceCode can fail (e.g. the GLSLFX/Sdr parser plugin isn't
+    // registered or the source fails to parse); bail out instead of dereferencing null.
+    if (!sdrSurfaceNode || !sdrSurfaceNode->IsValid())
+    {
+        TF_RUNTIME_ERROR("The 2D material surface shader could not be parsed.");
+        return nullptr;
+    }
+
     auto terminalsDs = HdRetainedContainerDataSource::New(
         HdMaterialTerminalTokens->surface, HdMaterialConnectionSchema::Builder().Build());
 

--- a/source/pageableBuffer/pageableDataSource.cpp
+++ b/source/pageableBuffer/pageableDataSource.cpp
@@ -276,11 +276,17 @@ bool WritePackedToDisk(const std::vector<uint8_t>& packed,
     std::unique_ptr<HdBufferPageEntry>& pageEntry,
     std::unique_ptr<HdPageFileManager>& pageFileManager, HdBufferState& bufferState)
 {
-    // Reuses an existing page entry (in-place update) when one already exists
-    if (pageEntry && pageEntry->IsValid())
+    // Reuses an existing page entry (in-place update) only when its slot is exactly the
+    // size of the packed blob. UpdatePage writes `pageEntry->Size()` bytes from `packed`,
+    // so a size mismatch would read past the end of `packed` (blob shrank) or truncate the
+    // on-disk data (blob grew). When the size differs, release the old slot and allocate a
+    // fresh one, mirroring HdPageableValue::SwapSceneToDisk.
+    if (pageEntry && pageEntry->IsValid() && pageEntry->Size() == packed.size())
         return pageFileManager->UpdatePage(*pageEntry, packed.data());
 
-    // Otherwise allocates a new slot in the page file.
+    // Otherwise allocates a new slot in the page file, releasing any stale one first.
+    if (pageEntry)
+        pageFileManager->ReleasePage(*pageEntry);
     pageEntry = pageFileManager->CreatePageEntry(packed.data(), packed.size());
     if (!pageEntry)
         return false;

--- a/source/sceneIndex/boundingBoxSceneIndex.cpp
+++ b/source/sceneIndex/boundingBoxSceneIndex.cpp
@@ -122,9 +122,11 @@ public:
     {
         if (name == HdTokens->displayColor)
         {
+            // A single color must use constant interpolation: vertex interpolation with one
+            // element does not match the box's point count (8) and is malformed.
             return BuildPrimvarDS(VtValue(VtVec3fArray { { _wireframeColor[0],
                                                       _wireframeColor[1], _wireframeColor[2] } }),
-                HdPrimvarSchemaTokens->vertex, HdPrimvarRoleTokens->color);
+                HdPrimvarSchemaTokens->constant, HdPrimvarRoleTokens->color);
         }
         return nullptr;
     }
@@ -416,7 +418,13 @@ void BoundingBoxSceneIndex::_PrimsAdded(
     {
         const SdfPath& path   = entry.primPath;
         HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(path);
-        if (prim.primType == HdPrimTypeTokens->mesh)
+        // Mirror the exact conditions GetPrim uses to convert a prim to basisCurves; otherwise
+        // the announced prim type disagrees with what GetPrim returns (e.g. for an excluded mesh
+        // or one with a null data source), leaving the renderer with a basisCurves type and no
+        // basisCurves topology.
+        if (prim.dataSource && !_IsExcluded(path) &&
+            ((prim.primType == HdPrimTypeTokens->mesh) ||
+                (prim.primType == HdPrimTypeTokens->basisCurves)))
         {
             // Converts meshes to basisCurve to display a bounding box.
             newEntries.push_back({ path, HdPrimTypeTokens->basisCurves });
@@ -449,7 +457,32 @@ void BoundingBoxSceneIndex::_PrimsDirtied(
         return;
     }
 
-    _SendPrimsDirtied(entries);
+    // The synthesized box vertices (primvars:points) are derived from the input prim's extent.
+    // When only `extent` is dirtied, downstream consumers tracking primvars:points would never
+    // be told the points changed, leaving a stale bounding box; remap the extent locator to also
+    // dirty primvars:points.
+    static const HdDataSourceLocator extentLocator = HdExtentSchema::GetDefaultLocator();
+    static const HdDataSourceLocator pointsLocator =
+        HdPrimvarsSchema::GetDefaultLocator().Append(HdPrimvarsSchemaTokens->points);
+
+    HdSceneIndexObserver::DirtiedPrimEntries newEntries;
+    bool remapped = false;
+    for (const HdSceneIndexObserver::DirtiedPrimEntry& entry : entries)
+    {
+        if (entry.dirtyLocators.Intersects(extentLocator))
+        {
+            HdDataSourceLocatorSet locators = entry.dirtyLocators;
+            locators.insert(pointsLocator);
+            newEntries.push_back({ entry.primPath, locators });
+            remapped = true;
+        }
+        else
+        {
+            newEntries.push_back(entry);
+        }
+    }
+
+    _SendPrimsDirtied(remapped ? newEntries : entries);
 }
 
 } // namespace HVT_NS

--- a/source/shadow/shadowMatrixComputation.cpp
+++ b/source/shadow/shadowMatrixComputation.cpp
@@ -136,7 +136,12 @@ void ShadowMatrixComputation::updateShadowMatrix(GfMatrix4d& matrix)
     GfVec3f pos = _lightPosition;
     if (_isDirectionalLight)
     {
-        // directional light (back it up to always contain the whole scene)
+        // directional light (back it up to always contain the whole scene).
+        // Guard against a zero light position, which would make Normalize() produce NaNs.
+        if (pos.GetLength() < 1e-6f)
+        {
+            pos = GfVec3f(0, 1, 0);
+        }
         pos.Normalize();
         auto worldSize = (_worldBox.GetMax() - _worldBox.GetMin()).GetLength();
         pos            = _worldBox.GetMidpoint() + (pos * worldSize * 0.55);
@@ -150,8 +155,13 @@ void ShadowMatrixComputation::updateShadowMatrix(GfMatrix4d& matrix)
     auto worldSize = (adjustedBox.GetMax() - adjustedBox.GetMin()).GetLength();
     frustum.SetNearFar(GfRange1d(0.1, worldSize * 1.01));
 
-    GfRotation rotation(
-        { 0, 0, 1 }, GfVec3d(_lightPosition[0], _lightPosition[1], _lightPosition[2]));
+    // Guard against a zero light position, which yields a degenerate rotation.
+    GfVec3d rotDir(_lightPosition[0], _lightPosition[1], _lightPosition[2]);
+    if (rotDir.GetLength() < 1e-6)
+    {
+        rotDir = GfVec3d(0, 1, 0);
+    }
+    GfRotation rotation({ 0, 0, 1 }, rotDir);
     frustum.SetRotation(rotation);
 
     auto viewMatrix = frustum.ComputeViewMatrix();

--- a/source/tasks/composeTask.cpp
+++ b/source/tasks/composeTask.cpp
@@ -210,6 +210,13 @@ const TfToken& ComposeTask::GetToken()
 
 std::ostream& operator<<(std::ostream& out, const HgiTextureHandle& handle)
 {
+    // A default-constructed handle (e.g. an unpopulated ComposeTaskParams) has no texture, so
+    // guard before dereferencing; streaming params is used for logging/dirty diagnostics.
+    if (!handle)
+    {
+        out << "<null texture>";
+        return out;
+    }
     HgiTextureDesc desc = handle.Get()->GetDescriptor();
     out << handle.GetId() << " " << desc.debugName << " " << desc.dimensions[0] << "x"
         << desc.dimensions[1] << "x" << desc.dimensions[2] << "x" << desc.format;

--- a/source/tasks/flashPickTask.cpp
+++ b/source/tasks/flashPickTask.cpp
@@ -366,6 +366,16 @@ void FlashPickTask::Execute(HdTaskContext* ctx)
     GfVec4i subRect(static_cast<int>(pickMin[0]), static_cast<int>(pickMin[1]),
         static_cast<int>(pickMax[0] - pickMin[0]), static_cast<int>(pickMax[1] - pickMin[1]));
 
+    // Clamp the sub-region to the render buffer. The projected pick frustum can extend
+    // outside the buffer (cursor near an edge, or a pick camera that differs from the
+    // render camera); without this the loops below would index the mapped ID/depth
+    // buffers (which hold exactly width*height elements) out of bounds.
+    const int minX = std::max(0, subRect[0]);
+    const int minY = std::max(0, subRect[1]);
+    const int maxX = std::min(width, subRect[0] + subRect[2]);
+    const int maxY = std::min(height, subRect[1] + subRect[3]);
+    subRect        = GfVec4i(minX, minY, std::max(0, maxX - minX), std::max(0, maxY - minY));
+
     // Resolve hits using Flash's primId-to-path map (bypasses HdRenderIndex).
     // Resolve code copied from HdxPickResult.
     HdRenderDelegate* rd = _index->GetRenderDelegate();

--- a/source/tasks/fxaaTask.cpp
+++ b/source/tasks/fxaaTask.cpp
@@ -123,6 +123,13 @@ void FXAATask::Execute(HdTaskContext* ctx)
     HgiTextureHandle aovTextureIntermediate;
     _GetTaskContextData(ctx, HdxAovTokens->colorIntermediate, &aovTextureIntermediate);
 
+    // Derive the texel size (1.0 / dimension) from the actual color texture so the sample
+    // spacing tracks viewport resizes, instead of relying on a possibly-stale params value.
+    const GfVec3i& dimensions = aovTexture->GetDescriptor().dimensions;
+    const GfVec2f uResolution(dimensions[0] > 0 ? 1.0f / static_cast<float>(dimensions[0]) : 0.0f,
+        dimensions[1] > 0 ? 1.0f / static_cast<float>(dimensions[1]) : 0.0f);
+    _shader->SetShaderConstants(sizeof(uResolution), &uResolution);
+
     aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
     _shader->BindTextures({ aovTexture });
     _shader->Draw(aovTextureIntermediate, HgiTextureHandle());

--- a/source/tasks/ssaoTask.cpp
+++ b/source/tasks/ssaoTask.cpp
@@ -16,6 +16,8 @@
 
 #include <hvt/tasks/resources.h>
 
+#include <algorithm>
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
@@ -99,6 +101,10 @@ int GetSpiralTurnCount(int sampleCount)
     };
     // clang-format on
 
+    if (sampleCount < 0)
+    {
+        return kSpiralTurnCounts[0];
+    }
     return sampleCount > kSampleCountMax ? 257 : kSpiralTurnCounts[sampleCount];
 }
 
@@ -410,8 +416,11 @@ void SSAOTask::ExecuteRawPass(
     uniforms.amount               = _params.ao.amount;
     uniforms.sampleRadius         = _params.ao.sampleRadius;
     uniforms.isScreenSampleRadius = _params.ao.isScreenSampleRadius ? 1 : 0;
-    uniforms.sampleCount          = _params.ao.sampleCount;
-    uniforms.spiralTurnCount      = GetSpiralTurnCount(_params.ao.sampleCount);
+    // Clamp to at least one sample: a non-positive count would index the spiral-turn table out
+    // of bounds and cause a divide-by-zero in the shader (obscurance / uSampleCount).
+    const int sampleCount         = std::max(1, _params.ao.sampleCount);
+    uniforms.sampleCount          = sampleCount;
+    uniforms.spiralTurnCount      = GetSpiralTurnCount(sampleCount);
     uniforms.isBlurEnabled        = _params.ao.isDenoiseEnabled ? 1 : 0;
     uniforms.isOrthographic       = _pCamera->GetProjection() == HdCamera::Orthographic ? 1 : 0;
 

--- a/source/tasks/wboitRenderTask.cpp
+++ b/source/tasks/wboitRenderTask.cpp
@@ -220,11 +220,6 @@ bool WbOitRenderTask::_InitTextures(
 
     const bool createOitBuffers = _wboitBuffers.empty();
 
-    if (!createOitBuffers && (aovBindings.front() == _wboitAovBindings.front()))
-    {
-        return false;
-    }
-
     // First AOV binding is expected to be the color one.
     if (aovBindings.front().aovName != HdAovTokens->color)
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(${_TARGET}
     tests/testWboitTask.cpp
     tests/testPageableBuffer.cpp
     tests/testOutlineTasks.cpp
+    tests/testBoundingBoxSceneIndex.cpp
 )
 
 # Is the generator a multi-config one?

--- a/test/tests/testBoundingBoxSceneIndex.cpp
+++ b/test/tests/testBoundingBoxSceneIndex.cpp
@@ -1,0 +1,197 @@
+// Copyright 2026 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <hvt/sceneIndex/boundingBoxSceneIndex.h>
+
+#include <pxr/pxr.h>
+
+#include <pxr/base/gf/vec3d.h>
+#include <pxr/imaging/hd/basisCurvesSchema.h>
+#include <pxr/imaging/hd/dataSourceLocator.h>
+#include <pxr/imaging/hd/extentSchema.h>
+#include <pxr/imaging/hd/primvarsSchema.h>
+#include <pxr/imaging/hd/retainedDataSource.h>
+#include <pxr/imaging/hd/retainedSceneIndex.h>
+#include <pxr/imaging/hd/sceneIndexObserver.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/xformSchema.h>
+
+#include <gtest/gtest.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+// The BoundingBoxSceneIndex converts meshes/basisCurves to a synthetic wireframe box. These tests
+// exercise its notice plumbing directly (no GPU/rendering): that _PrimsAdded announces the same
+// prim type GetPrim actually returns, and that dirtying `extent` also dirties `primvars:points`.
+
+namespace
+{
+
+/// Records the notices emitted by the scene index it observes.
+class RecordingObserver : public HdSceneIndexObserver
+{
+public:
+    AddedPrimEntries added;
+    RemovedPrimEntries removed;
+    DirtiedPrimEntries dirtied;
+
+    void PrimsAdded(HdSceneIndexBase const& /*sender*/, AddedPrimEntries const& entries) override
+    {
+        added.insert(added.end(), entries.begin(), entries.end());
+    }
+    void PrimsRemoved(
+        HdSceneIndexBase const& /*sender*/, RemovedPrimEntries const& entries) override
+    {
+        removed.insert(removed.end(), entries.begin(), entries.end());
+    }
+    void PrimsDirtied(
+        HdSceneIndexBase const& /*sender*/, DirtiedPrimEntries const& entries) override
+    {
+        dirtied.insert(dirtied.end(), entries.begin(), entries.end());
+    }
+    void PrimsRenamed(HdSceneIndexBase const& sender, RenamedPrimEntries const& entries) override
+    {
+        ConvertPrimsRenamedToRemovedAndAdded(sender, entries, &removed, &added);
+    }
+
+    void Clear()
+    {
+        added.clear();
+        removed.clear();
+        dirtied.clear();
+    }
+};
+
+/// Builds a minimal prim data source carrying only an extent (enough for the bounding box).
+HdContainerDataSourceHandle _MakePrimSourceWithExtent(GfVec3d const& mn, GfVec3d const& mx)
+{
+    HdContainerDataSourceHandle extentDs =
+        HdExtentSchema::Builder()
+            .SetMin(HdRetainedTypedSampledDataSource<GfVec3d>::New(mn))
+            .SetMax(HdRetainedTypedSampledDataSource<GfVec3d>::New(mx))
+            .Build();
+    return HdRetainedContainerDataSource::New(HdExtentSchemaTokens->extent, extentDs);
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// _PrimsAdded announces the same type GetPrim converts to.
+// ---------------------------------------------------------------------------
+
+TEST(TestBoundingBoxSceneIndex, MeshAnnouncedAsBasisCurvesMatchesGetPrim)
+{
+    auto input = HdRetainedSceneIndex::New();
+    auto bbox  = hvt::BoundingBoxSceneIndex::New(input);
+
+    RecordingObserver obs;
+    bbox->AddObserver(HdSceneIndexObserverPtr(&obs));
+
+    const SdfPath meshPath("/mesh");
+    input->AddPrims({ { meshPath, HdPrimTypeTokens->mesh,
+        _MakePrimSourceWithExtent(GfVec3d(-1), GfVec3d(1)) } });
+
+    // The added notice must announce basisCurves (the type GetPrim converts a mesh to).
+    ASSERT_EQ(obs.added.size(), 1u);
+    EXPECT_EQ(obs.added[0].primPath, meshPath);
+    EXPECT_EQ(obs.added[0].primType, HdPrimTypeTokens->basisCurves);
+
+    // GetPrim must agree with the announced type...
+    HdSceneIndexPrim prim = bbox->GetPrim(meshPath);
+    EXPECT_EQ(prim.primType, HdPrimTypeTokens->basisCurves);
+    ASSERT_TRUE(prim.dataSource);
+
+    // ...and provide real basisCurves topology + points, so the announced type is not dangling.
+    HdBasisCurvesSchema curves = HdBasisCurvesSchema::GetFromParent(prim.dataSource);
+    EXPECT_TRUE(curves.GetTopology().IsDefined());
+    HdPrimvarsSchema primvars = HdPrimvarsSchema::GetFromParent(prim.dataSource);
+    EXPECT_TRUE(primvars.GetPrimvar(HdPrimvarsSchemaTokens->points).IsDefined());
+}
+
+TEST(TestBoundingBoxSceneIndex, NonConvertiblePrimForwardedUnchanged)
+{
+    auto input = HdRetainedSceneIndex::New();
+    auto bbox  = hvt::BoundingBoxSceneIndex::New(input);
+
+    RecordingObserver obs;
+    bbox->AddObserver(HdSceneIndexObserverPtr(&obs));
+
+    static const TfToken kScope("scope");
+    const SdfPath path("/scope");
+    input->AddPrims({ { path, kScope, _MakePrimSourceWithExtent(GfVec3d(-1), GfVec3d(1)) } });
+
+    // A non-mesh/non-basisCurves prim (even with a valid data source) must pass through unchanged.
+    ASSERT_EQ(obs.added.size(), 1u);
+    EXPECT_EQ(obs.added[0].primType, kScope);
+    EXPECT_EQ(bbox->GetPrim(path).primType, kScope);
+}
+
+// ---------------------------------------------------------------------------
+// _PrimsDirtied remaps `extent` invalidation to also invalidate `primvars:points`.
+// ---------------------------------------------------------------------------
+
+TEST(TestBoundingBoxSceneIndex, DirtyingExtentAlsoDirtiesPoints)
+{
+    auto input = HdRetainedSceneIndex::New();
+    auto bbox  = hvt::BoundingBoxSceneIndex::New(input);
+
+    RecordingObserver obs;
+    bbox->AddObserver(HdSceneIndexObserverPtr(&obs));
+
+    const SdfPath meshPath("/mesh");
+    input->AddPrims({ { meshPath, HdPrimTypeTokens->mesh,
+        _MakePrimSourceWithExtent(GfVec3d(-1), GfVec3d(1)) } });
+    obs.Clear();
+
+    const HdDataSourceLocator extentLocator = HdExtentSchema::GetDefaultLocator();
+    input->DirtyPrims({ { meshPath, extentLocator } });
+
+    ASSERT_EQ(obs.dirtied.size(), 1u);
+    const HdDataSourceLocatorSet& locators = obs.dirtied[0].dirtyLocators;
+
+    const HdDataSourceLocator pointsLocator =
+        HdPrimvarsSchema::GetDefaultLocator().Append(HdPrimvarsSchemaTokens->points);
+
+    EXPECT_TRUE(locators.Intersects(extentLocator))
+        << "The original extent invalidation must be preserved.";
+    EXPECT_TRUE(locators.Intersects(pointsLocator))
+        << "Dirtying extent must also dirty the derived primvars:points.";
+}
+
+TEST(TestBoundingBoxSceneIndex, DirtyingUnrelatedLocatorDoesNotDirtyPoints)
+{
+    auto input = HdRetainedSceneIndex::New();
+    auto bbox  = hvt::BoundingBoxSceneIndex::New(input);
+
+    RecordingObserver obs;
+    bbox->AddObserver(HdSceneIndexObserverPtr(&obs));
+
+    const SdfPath meshPath("/mesh");
+    input->AddPrims({ { meshPath, HdPrimTypeTokens->mesh,
+        _MakePrimSourceWithExtent(GfVec3d(-1), GfVec3d(1)) } });
+    obs.Clear();
+
+    const HdDataSourceLocator xformLocator = HdXformSchema::GetDefaultLocator();
+    input->DirtyPrims({ { meshPath, xformLocator } });
+
+    ASSERT_EQ(obs.dirtied.size(), 1u);
+    const HdDataSourceLocatorSet& locators = obs.dirtied[0].dirtyLocators;
+
+    const HdDataSourceLocator pointsLocator =
+        HdPrimvarsSchema::GetDefaultLocator().Append(HdPrimvarsSchemaTokens->points);
+
+    EXPECT_TRUE(locators.Intersects(xformLocator));
+    EXPECT_FALSE(locators.Intersects(pointsLocator))
+        << "Only extent invalidation should be remapped to primvars:points.";
+}

--- a/test/tests/testComposeTask.cpp
+++ b/test/tests/testComposeTask.cpp
@@ -26,6 +26,7 @@
 #include <hvt/sceneIndex/boundingBoxSceneIndex.h>
 #include <hvt/sceneIndex/displayStyleOverrideSceneIndex.h>
 #include <hvt/sceneIndex/wireFrameSceneIndex.h>
+#include <hvt/tasks/composeTask.h>
 #include <hvt/tasks/resources.h>
 
 #include <pxr/pxr.h>
@@ -34,6 +35,8 @@
 
 #include <gtest/gtest.h>
 
+#include <sstream>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace
@@ -41,6 +44,18 @@ namespace
 constexpr int imageWidth { 1024 };
 constexpr int imageHeight { 768 };
 } // namespace
+
+// Streaming a default-constructed ComposeTaskParams (which holds a null texture handle) must not
+// dereference the null handle. This is a pure unit test and needs no GPU context.
+TEST(TestComposeTaskParams, StreamDefaultParamsDoesNotDereferenceNull)
+{
+    hvt::ComposeTaskParams params;
+
+    std::ostringstream oss;
+    EXPECT_NO_THROW(oss << params);
+    // The null handle should be reported textually, not crash.
+    EXPECT_NE(oss.str().find("<null texture>"), std::string::npos);
+}
 
 // NOTE: Android unit test framework does not report the error message making it impossible to fix
 // issues. Refer to OGSMOD-5546.

--- a/test/tests/testDataSource.cpp
+++ b/test/tests/testDataSource.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 // ===========================================================================
@@ -151,6 +153,51 @@ TEST(TestDataSource, Registry_DuplicateRegistration_Fails)
 
     EXPECT_TRUE(reg.registerFileTypes(desc));
     EXPECT_FALSE(reg.registerFileTypes(desc));
+}
+
+TEST(TestDataSource, Registry_GetFileTypesDescByIndex_BoundsChecked)
+{
+    auto& reg = hvt::DataSourceRegistry::registry();
+
+    hvt::DataSourceRegistry::FileTypesDesc desc;
+    desc.extensions = { ".test_idx_ext" };
+    desc.creator    = nullptr;
+    ASSERT_TRUE(reg.registerFileTypes(desc));
+
+    const size_t count = reg.fileTypesDescCount();
+    ASSERT_GT(count, 0u);
+
+    // Every in-range index must be accessible.
+    for (size_t i = 0; i < count; ++i)
+    {
+        EXPECT_NO_THROW((void)reg.getFileTypesDesc(i));
+    }
+
+    // Out-of-range access must throw std::out_of_range rather than be undefined behavior.
+    EXPECT_THROW((void)reg.getFileTypesDesc(count), std::out_of_range);
+}
+
+// ===========================================================================
+// AreaLightInfo
+// ===========================================================================
+
+TEST(TestDataSource, AreaLightInfo_DefaultType_IsRect)
+{
+    // A default-constructed AreaLightInfo must have a determinate type.
+    hvt::SceneDataSource::AreaLightInfo info;
+    EXPECT_EQ(info.type, hvt::SceneDataSource::AreaLightType::Rect);
+    EXPECT_TRUE(info.path.IsEmpty());
+}
+
+TEST(TestDataSource, Default_GetAreaLight_IsFalse_AndLeavesTypeDeterminate)
+{
+    ConcreteDataSource ds;
+    EXPECT_EQ(ds.getAreaLightCount(), 0u);
+
+    hvt::SceneDataSource::AreaLightInfo info;
+    EXPECT_FALSE(ds.getAreaLight(0, info));
+    // A failed query must not leave `type` indeterminate for the caller to read.
+    EXPECT_EQ(info.type, hvt::SceneDataSource::AreaLightType::Rect);
 }
 
 // ===========================================================================

--- a/test/tests/testTaskManager.cpp
+++ b/test/tests/testTaskManager.cpp
@@ -867,6 +867,33 @@ HVT_TEST(TestTaskManager, insertionOrdering)
 }
 
 // ---------------------------------------------------------------------------
+// insertAfter with an empty target position appends at the end.
+// ---------------------------------------------------------------------------
+
+HVT_TEST(TestTaskManager, insertAfterEmptyPositionAppends)
+{
+    TaskManagerFixture f;
+
+    static const TfToken kTaskA("TaskA");
+    static const TfToken kTaskB("TaskB");
+
+    const SdfPath pathA = f.taskManager->AddTask<HdxAovInputTask>(kTaskA, nullptr, nullptr);
+
+    // insertAfter with an empty atPos resolves to a past-the-end position; incrementing that
+    // iterator used to be undefined behavior. The task should simply be appended at the end.
+    const SdfPath pathB = f.taskManager->AddTask<HdxAovInputTask>(
+        kTaskB, nullptr, nullptr, SdfPath(), hvt::TaskManager::InsertionOrder::insertAfter);
+
+    ASSERT_FALSE(pathB.IsEmpty());
+    ASSERT_TRUE(f.taskManager->HasTask(pathB));
+
+    auto tasks = f.taskManager->GetTasks(hvt::TaskFlagsBits::kExecutableBit);
+    ASSERT_EQ(tasks.size(), 2u);
+    ASSERT_EQ(tasks[0].get(), f.pRenderIndex->GetTask(pathA).get());
+    ASSERT_EQ(tasks[1].get(), f.pRenderIndex->GetTask(pathB).get());
+}
+
+// ---------------------------------------------------------------------------
 // AddRenderTask convenience sets the correct task flags.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Addresses a batch of defects surfaced during a full code review of the Hydra Viewport Toolbox, grouped by severity, plus some targeted unit tests. No public API changes: every fix is either defensive (bounds checks, null guards) or a correctness fix to existing behavior.

### Changes Made

**Critical / High**

- `flashPickTask`: clamp the pick sub-region to the render buffer to stop an out-of-bounds read when the pick frustum extends past the buffer edges.
- `pageableDataSource`: reuse a page slot only when its size matches the packed blob; otherwise reallocate, avoiding OOB reads / on-disk truncation.
- `renderBufferManager`: guard a null color backing buffer before dereferencing.
- `geometry`: bail out when the 2D material surface shader fails to parse instead of dereferencing a null `Sdr` node.

**Medium**

- `renderBufferManager`: decide the progressive-render clear from the real previous-vs-new AOV output comparison.
- `lightingManager`: remove every excess light when the active count shrinks by more than one.
- `boundingBoxSceneIndex`: announce the same prim type `GetPrim` converts to, and remap `extent` invalidation to also dirty `primvars:points`.
- `composeTask`: null-guard the `ComposeTaskParams` stream operator.
- `fxaaTask`: derive `uResolution` from the color texture so it tracks viewport resizes.

**Low**

- `copyDepthShader`: destroy shader functions on the compile-failure paths.
- `taskManager`: guard `++end()` on `insertAfter` and skip null tasks from the render index.
- `viewportEngine`: bounds-check `xformOps` before indexing.
- `ssaoTask`: clamp `sampleCount` to avoid OOB table access and divide-by-zero.
- `wboitRenderTask`: drop a dead early-out that never fired.
- `dataSourceRegistry`: bounds-check `getFileTypesDesc(index)`.
- `shadowMatrixComputation`: guard degenerate (zero) light positions.
- `dataSource`: default-initialize `AreaLightInfo::type`.
- `selectionHelper`: null-check the `engine` argument.

**Tests**

- New GPU-free scene-index test (`testBoundingBoxSceneIndex.cpp`) for `BoundingBoxSceneIndex` notice plumbing: the announced prim type matches `GetPrim`, non-convertible prims pass through unchanged, and dirtying `extent` also dirties `primvars:points`.
- Regression tests for the registry bounds check, `AreaLightInfo` default type, `TaskManager` `insertAfter`-at-end, and the `ComposeTaskParams` null stream operator.

## Testing

Built with warnings-as-errors and ran the newly added unit tests locally. A few fixes (progressive-clear, FXAA resolution, shader-function leak, lighting reconciliation, pageable re-page-on-resize) are not reachable through public APIs without a GPU pipeline or extra harness, so they are covered indirectly by existing image-comparison tests rather than new unit tests.

### Test Configuration
- **Platform(s) tested**: macOS 15 (Darwin 25.5.0, Apple M3 Pro)
- **Build configuration(s)**: All cmake presets
- **Render delegate(s)**: Storm (Metal)
- **OpenUSD version**: 0.26.5 (v26.05)

### Tests Performed
- [x] Existing unit tests pass
- [x] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
