### PR TITLE
Clarify agent docs and public API documentation

### DIFF
--- a/.claude/skills/openusd-coding-style/SKILL.md
+++ b/.claude/skills/openusd-coding-style/SKILL.md
@@ -67,14 +67,15 @@ Apache-2.0 header, using the **current calendar year**. Copy from `source/tasks/
 
 ## Export macro (`HVT_API`, from `include/hvt/api.h`)
 
-- Every **public API class and struct** in `include/hvt/` must be declared with `HVT_API`, e.g.
-  `class HVT_API BlurTask`, `struct HVT_API BlurTaskParams`.
+- Every **public API class and struct** in `include/hvt/` that is compiled into the library must be
+  declared with `HVT_API`, e.g. `class HVT_API BlurTask`, `struct HVT_API BlurTaskParams`.
 - Put `HVT_API` on the params' **free operators** declared in the header
   (`HVT_API bool operator==(BlurTaskParams const&, BlurTaskParams const&);` and `operator!=`,
   `operator<<`).
-- **Exception:** scene-index filter subclasses of `HdSingleInputFilteringSceneIndexBase` put
-  `HVT_API` on public/protected members instead of the class — see
-  `include/hvt/sceneIndex/boundingBoxSceneIndex.h`.
+- **Exceptions:** templates and header-only/inline types must omit `HVT_API` (MSVC C2491) — see
+  `pageableConcepts.h`, `pageableStrategies.h`, `geometry.h`. Scene-index filter subclasses of
+  `HdSingleInputFilteringSceneIndexBase` put `HVT_API` on public/protected members instead of the
+  class — see `include/hvt/sceneIndex/boundingBoxSceneIndex.h`.
 
 ## See also
 

--- a/.claude/skills/openusd-coding-style/SKILL.md
+++ b/.claude/skills/openusd-coding-style/SKILL.md
@@ -67,13 +67,14 @@ Apache-2.0 header, using the **current calendar year**. Copy from `source/tasks/
 
 ## Export macro (`HVT_API`, from `include/hvt/api.h`)
 
-Actual practice in this tree (follow it):
-
-- Put `HVT_API` on **exported classes/structs**, e.g. `class HVT_API BlurTask`,
-  `struct HVT_API BlurTaskParams`.
+- Every **public API class and struct** in `include/hvt/` must be declared with `HVT_API`, e.g.
+  `class HVT_API BlurTask`, `struct HVT_API BlurTaskParams`.
 - Put `HVT_API` on the params' **free operators** declared in the header
   (`HVT_API bool operator==(BlurTaskParams const&, BlurTaskParams const&);` and `operator!=`,
   `operator<<`).
+- **Exception:** scene-index filter subclasses of `HdSingleInputFilteringSceneIndexBase` put
+  `HVT_API` on public/protected members instead of the class — see
+  `include/hvt/sceneIndex/boundingBoxSceneIndex.h`.
 
 ## See also
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,8 +4,8 @@ This repository's canonical guidance for AI coding agents lives in
 [`AGENTS.md`](../AGENTS.md) at the repo root. **Read it first.**
 
 It covers what the project is, the repository layout, the core architecture reading order,
-build/test commands (including fast single-test iteration), coding conventions, CI behavior,
-and a "do not" list.
+build/test commands (including fast single-test iteration), coding conventions, and a "do not"
+list. **CI workflows** are documented in [`README.md`](../README.md) § Continuous Integration.
 
 Additional references:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,9 +132,11 @@ Baseline conventions below always apply. Deeper, on-demand guidance lives in `.c
 - **Formatting:** match house style with the repo's `.clang-format` (and `.editorconfig`); run
   `clang-format` on changed files before committing.
 - **Namespace:** `HVT_NS` (generated in `include/hvt/namespace.h` at configure time).
-- **Export macro:** every **public API class and struct** in `include/hvt/` must be declared with
-  `HVT_API` (from `include/hvt/api.h`), e.g. `class HVT_API BlurTask`, `struct HVT_API BlurTaskParams`.
-  Also put `HVT_API` on params' free operators (`operator==`/`!=`/`<<`). **Exception:** scene-index
+- **Export macro:** every **public API class and struct** in `include/hvt/` that is compiled into
+  the library must be declared with `HVT_API` (from `include/hvt/api.h`), e.g.
+  `class HVT_API BlurTask`, `struct HVT_API BlurTaskParams`. Also put `HVT_API` on params' free
+  operators (`operator==`/`!=`/`<<`). **Exceptions:** templates and header-only/inline types omit
+  it (MSVC C2491 — see `pageableConcepts.h`, `pageableStrategies.h`, `geometry.h`); scene-index
   filter subclasses of `HdSingleInputFilteringSceneIndexBase` put `HVT_API` on public/protected
   members instead of the class — see `include/hvt/sceneIndex/boundingBoxSceneIndex.h`.
 - **Hydra tasks:** extend `pxr::HdxTask`; implement `_Sync`, `Prepare`, `Execute`; use a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Utilities can be used together or independently. When adding code, decide whethe
 | `include/hvt/resources/shaders/` | GLSLFX shader programs used by tasks |
 | `docs/` | Architecture and feature design docs — **read before large changes** |
 | `test/tests/` | Unit and image-comparison tests — **backbone for library validation** |
-| `test/howTos/` | Usage demonstrations (`howTo01`–`howTo20`) — **one per feature; also run as tests** |
+| `test/howTos/` | Usage demonstrations (`howTo01`–`howTo11`, `howTo19`–`howTo21`; gaps 12–18 unused) — **one per feature; also run as tests** |
 | `test/data/baselines/` | Golden images for rendered output tests |
 | `cmake/` | Build helpers (including vcpkg setup) |
 | `externals/vcpkg/` | vcpkg submodule — **do not edit** |
@@ -49,19 +49,31 @@ Utilities can be used together or independently. When adding code, decide whethe
 3. [docs/renderbuffermgr.md](docs/renderbuffermgr.md) — AOV / render buffer Bprims
 4. [docs/lightingmgr.md](docs/lightingmgr.md) — built-in light Sprims
 
-Each `FramePass` owns a shared `HdRetainedSceneIndex` and three managers (tasks, buffers,
-lights). Tasks are `HdxTask` subclasses registered through `TaskManager::AddTask`.
+Each `FramePass` owns a render pipeline: a `TaskBackend` (Scene Index or Scene Delegate),
+three managers (tasks, buffers, lights), and backend-specific prim storage. Tasks are
+`HdxTask` subclasses registered through `TaskManager::AddTask`.
+
+| Backend | Prim storage | Notes |
+|---------|--------------|-------|
+| **Scene Index (SI)** — default on USD ≥ 25.05 | Shared `HdRetainedSceneIndex` | Task/buffer/light prims live in the scene index |
+| **Scene Delegate (SD)** | `HdSceneDelegate` sync delegate | Used when legacy SD is required (older USD) |
+
+See [docs/framepass.md](docs/framepass.md) (TaskBackend abstraction) for selection via
+`UseLegacySceneDelegate()` / `SetUseLegacySceneDelegate()` in `taskBackend.h`.
 
 ```
 FramePass
-  ├── HdRetainedSceneIndex (shared)
+  ├── TaskBackend (SI or SD)
+  │     ├── [SI] HdRetainedSceneIndex  (task, buffer, light, camera prims)
+  │     └── [SD] SyncDelegate
   ├── TaskManager          → HdxTask pipeline (docs/taskmgr.md)
   ├── RenderBufferManager  → AOV Bprims (docs/renderbuffermgr.md)
   └── LightingManager      → light Sprims (docs/lightingmgr.md)
 ```
 
-Tasks are stored as scene-index prims and executed in list order. Task commit functions run
-before each frame to sync params from application state.
+Tasks are stored through the active `TaskBackend` (as scene-index prims in SI mode, or via the
+sync delegate in SD mode) and executed in list order. Task commit functions run before each frame
+to sync params from application state.
 
 ## Build and test
 
@@ -117,7 +129,10 @@ substitute for the broader unit test suite in `test/tests/`.
 | Register tasks in a frame pass | `include/hvt/engine/taskCreationHelpers.h`, `test/howTos/howTo10_CustomListOfTasks.cpp` |
 | Selection / outline highlighting | `docs/outline.md`, `test/howTos/howTo21_UseOutlineManager.cpp` (recommended wrapper), `test/howTos/howTo20_UseOutlineTasks.cpp` (raw tasks) |
 | Transparency (WBOIT) | `docs/wboit.md`, `test/howTos/howTo19_UseWBOITRenderTask.cpp` |
-| Scene index filters (wireframe, bbox) | `include/hvt/sceneIndex/`, `test/howTos/howTo08_*`, `howTo09_*` |
+| Flash picking | `include/hvt/tasks/flashPickTask.h`, `CreateFlashPickTask` in `include/hvt/engine/taskCreationHelpers.h`, `test/tests/testTaskHelpers.cpp` |
+| Show/hide and scale USD prims | `include/hvt/engine/viewportEngine.h` — `UpdatePrim`, `CreateSelectBox`, `CreateAxisTripod` (no dedicated how-to yet) |
+| Partial viewport display (framing clip) | `test/tests/testPartialDisplay.cpp` — `CameraUtilFraming` via `FramePassParams::viewInfo.framing` |
+| Scene index filters (wireframe, bbox, display style) | `include/hvt/sceneIndex/`, `test/howTos/howTo08_*`, `howTo09_*` |
 | Memory paging | `source/pageableBuffer/README.md`, `test/tests/testPageableBuffer.cpp` |
 | Fix a failing test | Start in `test/tests/`; check platform skips in feature docs |
 | Learn how to use a feature | Matching How-to in `test/howTos/` and [test/README.md](test/README.md) |
@@ -135,8 +150,11 @@ Baseline conventions below always apply. Deeper, on-demand guidance lives in `.c
 - **Formatting:** match house style with the repo's `.clang-format` (and `.editorconfig`); run
   `clang-format` on changed files before committing.
 - **Namespace:** `HVT_NS` (generated in `include/hvt/namespace.h` at configure time).
-- **Export macro:** `HVT_API` (`include/hvt/api.h`) on exported classes/structs (e.g.
-  `class HVT_API BlurTask`) and on the params' free operators (`operator==`/`!=`/`<<`).
+- **Export macro:** every **public API class and struct** in `include/hvt/` must be declared with
+  `HVT_API` (from `include/hvt/api.h`), e.g. `class HVT_API BlurTask`, `struct HVT_API BlurTaskParams`.
+  Also put `HVT_API` on params' free operators (`operator==`/`!=`/`<<`). **Exception:** scene-index
+  filter subclasses of `HdSingleInputFilteringSceneIndexBase` put `HVT_API` on public/protected
+  members instead of the class — see `include/hvt/sceneIndex/boundingBoxSceneIndex.h`.
 - **Hydra tasks:** extend `pxr::HdxTask`; implement `_Sync`, `Prepare`, `Execute`; use a
   params struct with `operator==` for dirty tracking (see the `create-hvt-task` skill).
 - **Task wiring:** tasks communicate through `HdTaskContext` texture tokens, not direct coupling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,27 +53,9 @@ Each `FramePass` owns a render pipeline: a `TaskBackend` (Scene Index or Scene D
 three managers (tasks, buffers, lights), and backend-specific prim storage. Tasks are
 `HdxTask` subclasses registered through `TaskManager::AddTask`.
 
-| Backend | Prim storage | Notes |
-|---------|--------------|-------|
-| **Scene Index (SI)** — default on USD ≥ 25.05 | Shared `HdRetainedSceneIndex` | Task/buffer/light prims live in the scene index |
-| **Scene Delegate (SD)** | `HdSceneDelegate` sync delegate | Used when legacy SD is required (older USD) |
-
-See [docs/framepass.md](docs/framepass.md) (TaskBackend abstraction) for selection via
-`UseLegacySceneDelegate()` / `SetUseLegacySceneDelegate()` in `taskBackend.h`.
-
-```
-FramePass
-  ├── TaskBackend (SI or SD)
-  │     ├── [SI] HdRetainedSceneIndex  (task, buffer, light, camera prims)
-  │     └── [SD] SyncDelegate
-  ├── TaskManager          → HdxTask pipeline (docs/taskmgr.md)
-  ├── RenderBufferManager  → AOV Bprims (docs/renderbuffermgr.md)
-  └── LightingManager      → light Sprims (docs/lightingmgr.md)
-```
-
-Tasks are stored through the active `TaskBackend` (as scene-index prims in SI mode, or via the
-sync delegate in SD mode) and executed in list order. Task commit functions run before each frame
-to sync params from application state.
+See [docs/framepass.md](docs/framepass.md) (TaskBackend abstraction) for the SI/SD backend
+comparison, the pipeline diagram, and backend selection via `UseLegacySceneDelegate()` /
+`SetUseLegacySceneDelegate()` in `taskBackend.h`.
 
 ## Build and test
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ For more information or to customize the configuration, see [Using CMake Presets
 
 - [Architecture and design docs](docs/README.md) — how HVT simplifies and extends OpenUSD Hydra
 - [Unit tests](test/tests/) — validation suite (many tests per feature)
-- [How-to examples](test/howTos/) — usage demonstrations (`howTo01`–`howTo20`, one per feature); see [test/README.md](test/README.md)
-- [AGENTS.md](AGENTS.md) — guide for AI coding agents and contributors (layout, conventions, CI)
+- [How-to examples](test/howTos/) — usage demonstrations (`howTo01`–`howTo11`, `howTo19`–`howTo21`; gaps 12–18 unused); see [test/README.md](test/README.md)
+- [AGENTS.md](AGENTS.md) — guide for AI coding agents and contributors (layout, conventions); CI is documented below
 - [CLAUDE.md](CLAUDE.md) — Claude Code entry point (imports `AGENTS.md`); on-demand skills live in `.claude/skills/`
 
 > **Note:** Claude Code support (`.claude/`, `AGENTS.md`, and related files) is provided for contributors who choose to use it. **No AI agent or specific editor is required** to build, test, or contribute to this repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ HVT-specific rendering features — **extensions** to stock OpenUSD/Hydra (see a
 | Doc | Topic | Key source | Unit tests (`test/tests/`) | How-to (`test/howTos/`) |
 |-----|-------|------------|----------------------------|-------------------------|
 | [outline.md](outline.md) | GPU selection/highlight outlines (ID-buffer edge detection) | `include/hvt/tasks/outline/`, `include/hvt/resources/shaders/outline*.glslfx` | `testOutlineManager.cpp`, `testOutlineTasks.cpp` (many cases) | `howTo21_UseOutlineManager.cpp` (recommended), `howTo20_UseOutlineTasks.cpp` (raw tasks) |
+| — | Flash picking | `include/hvt/tasks/flashPickTask.h`, `CreateFlashPickTask` | `testTaskHelpers.cpp` (params) | — |
 | [wboit.md](wboit.md) | Weighted blended order-independent transparency | `include/hvt/tasks/wboitRenderTask.h`, `wboitResolveTask.h` | `testWboitTask.cpp` | `howTo19_UseWBOITRenderTask.cpp` |
 
 ## Build and tooling
@@ -66,7 +67,7 @@ HVT-specific rendering features — **extensions** to stock OpenUSD/Hydra (see a
 
 | Area | Location | Simplify / extend | Notes |
 |------|----------|-------------------|-------|
-| Viewport engine entry points | `include/hvt/engine/viewportEngine.h`, `engine.h` | Simplify | Renderer and frame pass creation |
+| Viewport engine entry points | `include/hvt/engine/viewportEngine.h`, `engine.h` | Simplify | Renderer/frame-pass creation; `UpdatePrim` for USD visibility/scale (see header docs) |
 | Scene index filters | `include/hvt/sceneIndex/` | Extend | Wireframe, bounding box, display style overrides |
 | Geometry helpers | `include/hvt/geometry/` | Extend | Procedural mesh/polyline data sources |
 | Render tasks (SSAO, FXAA, blur, compose, …) | `include/hvt/tasks/` | Extend | Custom tasks and GLSLFX; see `howTo04`–`howTo06` |

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -66,6 +66,18 @@ Cursor does **not** use native project skills (`.cursor/skills/`) in this repo. 
 rule tells the agent to **read** matching files from `.claude/skills/` when the task fits. That
 avoids symlinks, Windows symlink quirks, and duplicated skill maintenance.
 
+## Cursor indexing vs access (`.cursorignore` / `.cursorindexingignore`)
+
+Two files control what Cursor agents see:
+
+| File | Effect |
+|------|--------|
+| [`.cursorignore`](../.cursorignore) | **Blocks read and edit** — agent cannot open these paths at all. Only `externals/vcpkg/` (never edited from this repo). |
+| [`.cursorindexingignore`](../.cursorindexingignore) | **Excluded from semantic index** but still **readable on demand** — `build/`, `install/`, `out/`, `test/data/baselines/`, and `**/*.png`. Keeps OpenUSD headers under `build/<preset>/vcpkg_installed/.../include/pxr/` openable when debugging Hydra API usage. |
+
+Golden-image baselines and build trees stay out of the index to save context, but agents can still
+open them when fixing image-comparison failures or inspecting vcpkg-installed headers.
+
 ## What we removed (and why)
 
 An earlier setup used several Cursor **scoped rules** (architecture, CMake, C++/Hydra patterns,

--- a/docs/framepass.md
+++ b/docs/framepass.md
@@ -13,7 +13,7 @@ HVT supports two rendering backends, selected at `FramePass` construction time:
 | **Scene Index** | SI | USD >= 25.05 (`HdLegacyTaskSchema`) | Prims live in an `HdRetainedSceneIndex` inserted into the render index |
 | **Scene Delegate** | SD | Any USD version | Prims are inserted/removed through an `HdSceneDelegate` (sync delegate) |
 
-The backend is chosen by `UseLegacySceneDelegate()` / `SetUseLegacySceneDelegate()` (see `taskBackend.h`). The default is SI (i.e. `UseLegacySceneDelegate()` returns `false`) on USD >= 25.05; on older versions only SD is available. Once a `FramePass` is initialized, its backend is fixed for its lifetime.
+The backend is chosen by `UseLegacySceneDelegate()` / `SetUseLegacySceneDelegate()` (see `taskBackend.h`). The default is SI (i.e. `UseLegacySceneDelegate()` returns `false`) on USD >= 25.05; on older versions only SD is available. Set the environment variable `HVT_USE_LEGACY_SCENE_DELEGATE` before constructing frame passes to force the SD backend process-wide (see `taskBackend.h`). Once a `FramePass` is initialized, its backend is fixed for its lifetime.
 
 ### TaskBackend abstraction
 

--- a/include/hvt/api.h
+++ b/include/hvt/api.h
@@ -13,9 +13,12 @@
 // limitations under the License.
 #pragma once
 
-/// Define an "HVT_API export symbol for the library. This depends on the platform and whether the
-/// library is being built or used. The symbol should be added to all public functions; it should
-/// *not* be added to classes in this project.
+/// Define an HVT_API export symbol for the library. This depends on the platform and whether the
+/// library is being built or used. All public API classes and structs in include/hvt/ must be
+/// declared with HVT_API (e.g. `class HVT_API BlurTask`). Also use it on exported free functions
+/// and on params' free operators. Scene-index filter subclasses of
+/// HdSingleInputFilteringSceneIndexBase are a documented exception: put HVT_API on public/protected
+/// members instead of the class (see boundingBoxSceneIndex.h).
 #if defined(_WIN32) || defined(_WIN64)
     #if defined(HVT_SHARED)
         #if defined(HVT_BUILD)

--- a/include/hvt/api.h
+++ b/include/hvt/api.h
@@ -14,11 +14,12 @@
 #pragma once
 
 /// Define an HVT_API export symbol for the library. This depends on the platform and whether the
-/// library is being built or used. All public API classes and structs in include/hvt/ must be
-/// declared with HVT_API (e.g. `class HVT_API BlurTask`). Also use it on exported free functions
-/// and on params' free operators. Scene-index filter subclasses of
-/// HdSingleInputFilteringSceneIndexBase are a documented exception: put HVT_API on public/protected
-/// members instead of the class (see boundingBoxSceneIndex.h).
+/// library is being built or used. All public API classes and structs in include/hvt/ that are
+/// compiled into the library must be declared with HVT_API (e.g. `class HVT_API BlurTask`). Also
+/// use it on exported free functions and on params' free operators. Exceptions: templates and
+/// header-only/inline types must omit it (MSVC C2491), and scene-index filter subclasses of
+/// HdSingleInputFilteringSceneIndexBase put HVT_API on public/protected members instead of the
+/// class (see boundingBoxSceneIndex.h).
 #if defined(_WIN32) || defined(_WIN64)
     #if defined(HVT_SHARED)
         #if defined(HVT_BUILD)

--- a/include/hvt/engine/basicLayerParams.h
+++ b/include/hvt/engine/basicLayerParams.h
@@ -100,10 +100,13 @@ struct HVT_API BasicLayerParams
     /// Enable selection is on by default.
     bool enableSelection { true };
 
-    /// Enable outline is off by default.
+    /// Enable legacy Hdx colorize-selection / outline tasks in the default task list when true.
+    /// Off by default. \note Unrelated to the GPU \c OutlineManager pipeline (howTo21,
+    /// docs/outline.md). For ID-buffer selection outlines use \c OutlineManager instead of toggling
+    /// this flag.
     bool enableOutline { false };
 
-    /// When enableSelection on selections objects are highlighted as a different color.
+    /// When \c enableSelection is true, selected objects are highlighted as a different color.
     /// The selectionColor is used to tint selected objects.
     PXR_NS::GfVec4f selectionColor { 1.0f, 1.0f, 0.0f, 1.0f };
     /// The locateColor is used to tint rollover objects.

--- a/include/hvt/engine/framePass.h
+++ b/include/hvt/engine/framePass.h
@@ -188,6 +188,13 @@ struct HVT_API FramePassParams : public BasicLayerParams
 
 /// A FramePass is used to render or select from a collection of Prims using a set of HdTasks and
 /// settable input parameters.
+///
+/// The pass uses a \c TaskBackend chosen at construction time: Scene Index (SI, default on USD >=
+/// 25.05) or Scene Delegate (SD). The backend is fixed for the lifetime of the pass after
+/// \c Initialize(). See \c UseLegacySceneDelegate() / \c SetUseLegacySceneDelegate() in
+/// \c taskBackend.h and [docs/framepass.md](../../../docs/framepass.md) for selection rules and the
+/// \c HVT_USE_LEGACY_SCENE_DELEGATE environment variable. Use \c GetRetainedSceneIndex() only on
+/// SI backends (\c framePassUtils.h).
 class HVT_API FramePass
 {
 public:
@@ -245,7 +252,7 @@ public:
     /// \brief Prepare and return the default list of render tasks.
     ///
     /// Before returning the list of render tasks to execute, the method first calls the underlying
-    /// TaksController to go through all the registered tasks to create them in the render index and
+    /// TaskController to go through all the registered tasks to create them in the render index and
     /// second, it finalizes their initialization by enabling or not a specific render task, by
     /// settings the render buffers when shared, adding (or not) the color correction step, etc.
     ///

--- a/include/hvt/engine/selectionSettingsProvider.h
+++ b/include/hvt/engine/selectionSettingsProvider.h
@@ -61,6 +61,8 @@ struct HVT_API SelectionSettings
 {
     unsigned int outlineRadius = 5;
     bool enableSelection       = true;
+    /// Enables legacy Hdx selection-outline tasks fed from \c BasicLayerParams::enableOutline
+    /// after the first \c GetRenderTasks() sync. Not used by \c OutlineManager.
     bool enableOutline         = true;
     PXR_NS::GfVec4f locateColor    = { 0, 0, 1, 1 };
     PXR_NS::GfVec4f selectionColor = { 1, 1, 0, 1 };

--- a/include/hvt/engine/taskCreationHelpers.h
+++ b/include/hvt/engine/taskCreationHelpers.h
@@ -169,7 +169,13 @@ HVT_API extern PXR_NS::SdfPath CreatePickFromRenderBufferTask(TaskManagerPtr& ta
     SelectionSettingsProviderWeakPtr const& selectionSettingsProvider,
     FnGetLayerSettings const& getLayerSettings);
 
-/// Creates the 'HdFlash' pick task.
+/// Creates the Flash-render-delegate pick task (\c FlashPickTask).
+///
+/// \c CreateDefaultTasks selects this automatically when the render index uses the Flash render
+/// delegate; otherwise it inserts \c CreatePickFromRenderBufferTask for Storm-style delegates.
+/// The task runs only during \c FramePass::Pick() when pick params are present in the task
+/// context.
+///
 /// \param taskManager The task manager to update.
 /// \param selectionSettingsProvider An accessor instance for selection settings.
 /// \param getLayerSettings Callback for accessing the layer settings.

--- a/include/hvt/engine/viewportEngine.h
+++ b/include/hvt/engine/viewportEngine.h
@@ -80,9 +80,9 @@ struct HVT_API USDSceneDelegateDescriptor
     PXR_NS::UsdStage* stage = nullptr;
     /// The render index to add the scene delegate to
     PXR_NS::HdRenderIndex* renderIndex = nullptr;
-    /// An optional list of paths to ignore in this scene delegate
+    /// An optional list of paths to exclude from this scene delegate.
     PXR_NS::SdfPathVector excludedPrimPaths;
-    /// The invised list of paths for this scene delegate
+    /// An optional list of paths forced invisible in this scene delegate.
     PXR_NS::SdfPathVector invisedPrimPaths;
 };
 
@@ -91,7 +91,7 @@ struct HVT_API USDSceneIndexDescriptor
 {
     /// The USD Stage to render
     PXR_NS::UsdStageRefPtr stage;
-    /// The render index to add the scene delegate to
+    /// The render index to add the scene index to
     PXR_NS::HdRenderIndex* renderIndex = nullptr;
 };
 
@@ -140,7 +140,7 @@ HVT_API extern void CreateUSDSceneDelegate(SceneDelegatePtr& sceneDelegate,
 HVT_API extern void UpdateSceneDelegate(SceneDelegatePtr& sceneDelegate,
     PXR_NS::UsdTimeCode frame = PXR_NS::UsdTimeCode::EarliestTime(), int refineLevelFallback = 0);
 
-/// Create a USD based scene index hierarchy.
+/// Create a USD scene-index hierarchy and insert the root into \p desc.renderIndex.
 /// \param sceneIndex An out param used to return the final scene index.
 /// \param stageSceneIndex An out param used to return the scene index holding the original USD
 /// stage.
@@ -160,18 +160,19 @@ inline PXR_NS::HdSceneIndexBaseRefPtr AppendOverridesSceneIndices(
     return inputScene;
 };
 
-/// Create a scene index with scene index filters implemented using USD asset features.
+/// Create a single root scene index for \p stage, optionally wrapped by \p callback filters.
+/// Use this overload when you manage render-index insertion yourself (typical in how-tos).
 /// \param stage The USD Stage to render.
-/// \param callback The only way to add scene index filters.
-/// \return Returns the created scene index instance.
+/// \param callback Optional chain of scene-index filters (defaults to no filters).
+/// \return The root scene index (not yet inserted into a render index).
 HVT_API extern PXR_NS::HdSceneIndexBaseRefPtr CreateUSDSceneIndex(PXR_NS::UsdStageRefPtr& stage,
     PXR_NS::UsdImagingCreateSceneIndicesInfo::SceneIndexAppendCallback const& callback =
         AppendOverridesSceneIndices);
 
-/// Create a scene index with scene index filters implemented using USD asset features.
+/// Create the full UsdImaging scene-index bundle for \p stage (stage, selection, overlays, …).
 /// \param stage The USD Stage to render.
-/// \param callback The only way to add scene index filters.
-/// \return Returns the created scene index instance.
+/// \param callback Optional chain of scene-index filters applied during creation.
+/// \return The UsdImaging scene-indices handle; use when you need selection or multiple roots.
 HVT_API extern PXR_NS::UsdImagingSceneIndices const CreateUSDSceneIndices(
     PXR_NS::UsdStageRefPtr& stage,
     PXR_NS::UsdImagingCreateSceneIndicesInfo::SceneIndexAppendCallback const& callback =
@@ -266,15 +267,23 @@ HVT_API extern void CreateSelectBox(
 HVT_API extern void CreateAxisTripod(PXR_NS::UsdStageRefPtr& stage, PXR_NS::SdfPath path,
     PXR_NS::GfVec3d const& position, float scale, bool isVisible);
 
-/// Updates a USD prim with position, scale, visibility, rotation, and child visibility settings.
-/// \param stage The USD stage containing the prim.
-/// \param path The path to the prim to update.
-/// \param position The new position for the prim.
-/// \param scale The scale factor for the prim (if > 0).
-/// \param isVisible Whether the main prim should be visible.
-/// \param rotation The rotation to apply to the prim.
-/// \param visibilityOverrides Optional map of child prim paths to visibility states. Only child
-/// prims that exist in the stage and are specified in the map will be affected.
+/// Updates a USD xformable prim's visibility, translation, rotation, scale, and optional child
+/// visibility overrides.
+///
+/// \param stage The USD stage containing the prim. Returns immediately if null.
+/// \param path The path to the prim to update. Returns immediately if invalid.
+/// \param position Translation written to the prim's existing \c TypeTranslate xform op.
+/// \param rotation Rotation written to the prim's existing \c TypeOrient xform op (identity skips
+/// the missing-op error).
+/// \param scale Scale factor written to the prim's existing \c TypeScale xform op when \p scale >
+/// 0. The value stored is \c scale * 0.5 (historical convention for gizmo geometry).
+/// \param isVisible Visibility of the root prim (\c MakeVisible / \c MakeInvisible).
+/// \param visibilityOverrides When \p isVisible is true, all descendants are made visible first,
+/// then each path in the map with value \c false is hidden. Ignored when \p isVisible is false.
+///
+/// \note The prim must be \c UsdGeomXformable with the expected xform ops already authored.
+/// Missing translate/scale ops log \c TF_RUNTIME_ERROR; missing orient logs an error only when
+/// \p rotation is non-identity.
 HVT_API extern void UpdatePrim(PXR_NS::UsdStageRefPtr& stage, PXR_NS::SdfPath const& path,
     PXR_NS::GfVec3d const& position, PXR_NS::GfRotation const& rotation, float scale,
     bool isVisible, std::map<PXR_NS::SdfPath, bool> const& visibilityOverrides = {});

--- a/include/hvt/sceneIndex/displayStyleOverrideSceneIndex.h
+++ b/include/hvt/sceneIndex/displayStyleOverrideSceneIndex.h
@@ -92,7 +92,7 @@ public:
     using RefineLevelParams = std::optional<int>;
 
     /// Sets the refine level (at data source locator displayStyle:refineLevel)
-    /// for every prim in the input scene inedx.
+    /// for every prim in the input scene index.
     ///
     /// \note If an empty optional value is provided, a null data source will be
     /// returned for the data source locator.

--- a/include/hvt/tasks/flashPickTask.h
+++ b/include/hvt/tasks/flashPickTask.h
@@ -46,7 +46,9 @@ namespace HVT_NS
 /// Parameters for the Flash-specific pick task.
 struct HVT_API FlashPickTaskParams
 {
+    /// Cull style used when rendering pick ID buffers.
     PXR_NS::HdCullStyle cullStyle = PXR_NS::HdCullStyleNothing;
+    /// Render tags passed to the pick render pass.
     PXR_NS::TfTokenVector renderTags;
 
     /// Camera to use for rendering the ID buffers.
@@ -54,6 +56,7 @@ struct HVT_API FlashPickTaskParams
 
     /// Framing / viewport information (mirrors HdxPickFromRenderBufferTaskParams).
     PXR_NS::CameraUtilFraming framing;
+    /// Optional window-policy override for pick framing.
     std::optional<PXR_NS::CameraUtilConformWindowPolicy> overrideWindowPolicy;
 
     bool operator==(FlashPickTaskParams const& other) const
@@ -67,8 +70,12 @@ struct HVT_API FlashPickTaskParams
 
 /// \class FlashPickTask
 ///
-/// A Flash-specific pick task that renders to its own ID buffers (primId,
+/// A Flash-render-delegate pick task that renders to its own ID buffers (primId,
 /// instanceId, elementId, depth) and resolves hits using HdxPickResult.
+///
+/// \c CreateDefaultTasks wires this task only when the render index uses the Flash render
+/// delegate (\c IsFlashRenderDelegate). Storm and other delegates use
+/// \c CreatePickFromRenderBufferTask instead.
 ///
 /// The task only executes when HdxPickTokens->pickParams is present in the
 /// task context (set by FramePass::Pick()), so there is no rendering overhead

--- a/include/hvt/tasks/outline/outlineManager.h
+++ b/include/hvt/tasks/outline/outlineManager.h
@@ -136,6 +136,11 @@ struct HVT_API OutlineInputs
 /// OutlineManager is a feature-level wrapper around the five internal outline tasks
 /// (three OutlinePrimIdsTask passes + one OutlineMaskTask + one OutlineOverlayTask).
 ///
+/// \note This is the GPU ID-buffer outline pipeline. It is independent of
+/// \c BasicLayerParams::enableOutline / \c SelectionSettings::enableOutline, which toggle legacy
+/// Hdx colorize-selection tasks in the default task list. Prefer \c OutlineManager for new work
+/// (see howTo21 and docs/outline.md).
+///
 /// It owns the task IDs, AOV texture bindings, and ordering inside the frame pass
 /// so consumers don't have to rediscover the correct wiring. State is push-based:
 /// call SetInputs() / SetStyle() whenever the host's selection or style changes.

--- a/test/README.md
+++ b/test/README.md
@@ -30,6 +30,7 @@ is typically **one How-to per feature**.
 - [How to use the SkyDome task](#HowTo11)
 - [How to use the WBOIT (transparency) task](#HowTo19)
 - [How to use the outline (selection highlight) tasks](#HowTo20)
+- [How to use the OutlineManager wrapper (recommended)](#HowTo21)
 
 # How to compile `Hydra Viewport Toolbox` in my environment <a name="HowTo00"></a>
 
@@ -552,55 +553,18 @@ Note: When the code accesses to a stage it can create the associated scene index
 The code to insert scene indice filters is then:
 
 ```cpp
-pxr::HdSceneIndexBaseRefPtr sceneIndex  = hvt::ViewportEngine::CreateUSDSceneIndex(stage.stage());
-sceneIndex = hvt::SceneIndexUtils::BoundingBoxSceneIndex::New(sceneIndex);
+pxr::HdSceneIndexBaseRefPtr sceneIndex = hvt::ViewportEngine::CreateUSDSceneIndex(stage.stage());
+sceneIndex = hvt::BoundingBoxSceneIndex::New(sceneIndex);
 renderIndex->RenderIndex()->InsertSceneIndex(sceneIndex, pxr::SdfPath::AbsoluteRootPath());
 ```
 
-## Implementation using a scene index filter based on a USD asset feature
+## Implementation using USD DrawMode (OpenUSD asset feature)
 
-The bounding box feature exists using the `DrawMode` USD asset feature. The insertion order is then slightly different compare to the previous case as it requires to insert the filter before the scene index creation i.e., the `DrawMode` is an USD feature, not an Hydra feature.
-
-```cpp
-auto AppendOverridesSceneIndices =
-    [](pxr::HdSceneIndexBaseRefPtr const& inputScene) -> pxr::HdSceneIndexBaseRefPtr {
-    return hvt::SceneIndexUtils::DrawModeSceneIndex::New(inputScene);
-};
-
-sceneIndex = hvt::ViewportEngine::CreateUSDSceneIndex(
-    stage.stage(), AppendOverridesSceneIndices);
-```
-
-The `DrawMode` scene index implementation can be:
-
-```cpp
-static HdContainerDataSourceHandle const& _DataSourceForcingBoundsDrawMode()
-{
-    static pxr::HdContainerDataSourceHandle result =
-        pxr::HdRetainedContainerDataSource::New(UsdImagingGeomModelSchema::GetSchemaToken(),
-            pxr::UsdImagingGeomModelSchema::Builder()
-                .SetApplyDrawMode(pxr::HdRetainedTypedSampledDataSource<bool>::New(true))
-                .SetDrawMode(pxr::HdRetainedTypedSampledDataSource<TfToken>::New(
-                    pxr::UsdImagingGeomModelSchemaTokens->bounds))
-                .SetDrawModeColor(pxr::HdRetainedTypedSampledDataSource<pxr::GfVec3f>::New(
-                    pxr::GfVec3f { 0.0f, 1.0f, 0.0f })) // The line color.
-                .Build());
-    return result;
-}
-
-pxr::HdSceneIndexPrim DrawModeSceneIndex::GetPrim(const pxr::SdfPath& primPath) const
-{
-    pxr::HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
-
-    if (prim.primType == pxr::HdPrimTypeTokens->mesh)
-    {
-        prim.dataSource = pxr::HdOverlayContainerDataSource::New(
-            _DataSourceForcingBoundsDrawMode(), prim.dataSource);
-    }
-
-    return prim;
-}
-```
+The bounding box can also be driven through USD's `DrawMode` schema (OpenUSD `UsdImaging`, not an
+HVT helper). That path inserts an override callback when creating the scene index — see OpenUSD
+`UsdImaging` scene-index documentation. The HVT-native filter approach above
+(`hvt::BoundingBoxSceneIndex`) is what [HowTo08](howTos/howTo08_UseBoundingBoxSceneIndex.cpp)
+demonstrates.
 
 # How to display the wire frame of a scene <a name="HowTo09"></a>
 
@@ -637,8 +601,8 @@ Unfortunately, that's specific to the `Storm` render delegate.
 // Step 2 - Adds the 'wireframe' scene index.
 
 sceneIndex = hvt::ViewportEngine::CreateUSDSceneIndex(stage.stage());
-sceneIndex = hvt::SceneIndexUtils::DisplayStyleOverrideSceneIndex::New(sceneIndex);
-sceneIndex = hvt::SceneIndexUtils::WireFrameSceneIndex::New(sceneIndex);
+sceneIndex = hvt::DisplayStyleOverrideSceneIndex::New(sceneIndex);
+sceneIndex = hvt::WireFrameSceneIndex::New(sceneIndex);
 
 renderIndex->RenderIndex()->InsertSceneIndex(sceneIndex, pxr::SdfPath::AbsoluteRootPath());
 ```
@@ -735,3 +699,16 @@ To enable WBOIT, set `TaskCreationOptions::useWbOit = true` in the `FramePassDes
 This example (refer to [HowTo20_UseOutlineTasks.cpp](howTos/howTo20_UseOutlineTasks.cpp) for implementation details) demonstrates GPU selection outlines using ID-buffer edge detection (`OutlinePrimIdsTask`, `OutlineMaskTask`, `OutlineOverlayTask`).
 
 :information_source: See [docs/outline.md](../docs/outline.md) for the full pipeline, shader details, and platform limitations (some tests skip Apple/Metal).
+
+# How to use the OutlineManager wrapper (recommended) <a name="HowTo21"></a>
+
+This example (refer to [HowTo21_UseOutlineManager.cpp](howTos/howTo21_UseOutlineManager.cpp) for
+implementation details) demonstrates the **recommended** high-level path for selection outlines
+via `hvt::Outline::OutlineManager`. It wraps the five internal outline tasks, AOV bindings, and
+commit logic so callers only call `Install`, `SetStyle`, and `SetInputs`.
+
+Prefer HowTo21 over [HowTo20](#HowTo20) for new integrations unless you need direct control over
+individual outline tasks.
+
+:information_source: See [docs/outline.md](../docs/outline.md) § OutlineManager for API details
+and [test/tests/testOutlineManager.cpp](../test/tests/testOutlineManager.cpp) for unit coverage.

--- a/test/README.md
+++ b/test/README.md
@@ -561,10 +561,10 @@ renderIndex->RenderIndex()->InsertSceneIndex(sceneIndex, pxr::SdfPath::AbsoluteR
 ## Implementation using USD DrawMode (OpenUSD asset feature)
 
 The bounding box can also be driven through USD's `DrawMode` schema (OpenUSD `UsdImaging`, not an
-HVT helper). That path inserts an override callback when creating the scene index — see OpenUSD
-`UsdImaging` scene-index documentation. The HVT-native filter approach above
-(`hvt::BoundingBoxSceneIndex`) is what [HowTo08](howTos/howTo08_UseBoundingBoxSceneIndex.cpp)
-demonstrates.
+HVT helper). That path inserts an override callback when creating the scene index — see
+`UsdImagingDrawModeSceneIndex` in `pxr/usdImaging/usdImaging/drawModeSceneIndex.h`. The HVT-native
+filter approach above (`hvt::BoundingBoxSceneIndex`) is what
+[HowTo08](howTos/howTo08_UseBoundingBoxSceneIndex.cpp) demonstrates.
 
 # How to display the wire frame of a scene <a name="HowTo09"></a>
 


### PR DESCRIPTION
Sync agent-facing documentation and public API header comments with post-merge reality after OutlineManager, dual SI/SD TaskBackend, and related merges. No runtime behavior changes — documentation only.

### Changes Made

- **Agent docs:** Update `AGENTS.md`, `README.md`, `test/README.md`, `docs/ai-agents.md`, and `.github/copilot-instructions.md` — howTo21 numbering, SI/SD architecture, `HVT_API` on public classes, CI pointer fixes, Cursor `.cursorignore` / `.cursorindexingignore` split
- **`test/README.md`:** Fix scene-index API examples (`BoundingBoxSceneIndex`, etc.), add HowTo21 / `OutlineManager` section
- **`UpdatePrim`:** Correct and expand Doxygen in `viewportEngine.h` (param order, xform-op requirements, scale semantics, child visibility)
- **`enableOutline`:** Disambiguate legacy Hdx tasks vs GPU `OutlineManager` in `basicLayerParams.h`, `selectionSettingsProvider.h`, `outlineManager.h`
- **`FramePass`:** Document SI/SD `TaskBackend` selection; link to `taskBackend.h` and `docs/framepass.md`; document `HVT_USE_LEGACY_SCENE_DELEGATE` in `docs/framepass.md`
- **Flash picking:** Document Flash vs Storm pick wiring in `flashPickTask.h` and `CreateFlashPickTask`
- **`CreateUSDSceneIndex`:** Clarify overload purposes in `viewportEngine.h`
- **`include/hvt/api.h`:** Align export macro comment with public-class `HVT_API` requirement and scene-index exception
- **`docs/README.md`:** Add flash-picking row; note `UpdatePrim` on viewport engine entry

## Testing

Documentation-only change — no code behavior modified. Verified paths and API names referenced in updated docs against current headers and how-tos.

### Test Configuration
- **Platform(s) tested**: N/A (docs only)
- **Build configuration(s)**: N/A
- **Render delegate(s)**: N/A
- **OpenUSD version**: N/A

### Tests Performed
- [x] Existing unit tests pass (not re-run — no code changes)
- [ ] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

- [ ] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
