### PR TITLE
Keep a shared OpenGL context current for Vulkan tests

### DIFF
--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -155,6 +155,71 @@ void OpenGLWindow::setWindowShouldClose()
     _shouldClose = true;
 }
 
+namespace
+{
+
+SDL_Window* gSharedWindow     = nullptr;
+SDL_GLContext gSharedGLContext = nullptr;
+
+} // anonymous namespace
+
+bool OpenGLWindow::createShared()
+{
+    static constexpr unsigned int glMajor = getGLMajorVersion();
+    static constexpr unsigned int glMinor = getGLMinorVersion();
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, glMajor);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, glMinor);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+    constexpr Uint32 windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN;
+
+    gSharedWindow = SDL_CreateWindow("HVT shared OpenGL context", SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED, 1, 1, windowFlags);
+    if (!gSharedWindow)
+    {
+        std::cerr << "Creation of the shared OpenGL SDL window failed: " << SDL_GetError()
+                  << std::endl;
+        return false;
+    }
+
+    gSharedGLContext = SDL_GL_CreateContext(gSharedWindow);
+    if (!gSharedGLContext)
+    {
+        std::cerr << "Creation of the shared OpenGL context failed: " << SDL_GetError()
+                  << std::endl;
+        SDL_DestroyWindow(gSharedWindow);
+        gSharedWindow = nullptr;
+        return false;
+    }
+
+    SDL_GL_MakeCurrent(gSharedWindow, gSharedGLContext);
+    return true;
+}
+
+void OpenGLWindow::makeSharedCurrent()
+{
+    if (gSharedWindow && gSharedGLContext)
+    {
+        SDL_GL_MakeCurrent(gSharedWindow, gSharedGLContext);
+    }
+}
+
+void OpenGLWindow::destroyShared()
+{
+    if (gSharedGLContext)
+    {
+        SDL_GL_DeleteContext(gSharedGLContext);
+        gSharedGLContext = nullptr;
+    }
+    if (gSharedWindow)
+    {
+        SDL_DestroyWindow(gSharedWindow);
+        gSharedWindow = nullptr;
+    }
+}
+
 OpenGLRendererContext::OpenGLRendererContext(int w, int h) : HydraRendererContext(w, h), _glWindow(w, h)
 {
     _imageCapture.flipVertically(true);

--- a/test/RenderingFramework/OpenGLTestContext.cpp
+++ b/test/RenderingFramework/OpenGLTestContext.cpp
@@ -24,6 +24,7 @@
 
 #include <filesystem>
 #include <mutex>
+#include <iostream>
 
 /// Convenience helper functions for internal use in unit tests
 namespace TestHelpers

--- a/test/RenderingFramework/OpenGLTestContext.h
+++ b/test/RenderingFramework/OpenGLTestContext.h
@@ -40,6 +40,10 @@ public:
     bool windowShouldClose() const;
     void setWindowShouldClose();
 
+    static bool createShared();
+    static void makeSharedCurrent();
+    static void destroyShared();
+
 private:
     SDL_Window* _window       = nullptr;
     SDL_GLContext _glContext   = nullptr;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -14,11 +14,28 @@
 
 #include <gtest/gtest.h>
 
+#include <RenderingFramework/OpenGLTestContext.h>
 #include <RenderingFramework/TestHelpers.h>
 #include <RenderingFramework/UsdHelpers.h>
 #include <RenderingFramework/TestFlags.h>
 
 #include <SDL2/SDL.h>
+
+namespace
+{
+
+/// Restores the shared OpenGL context before each test, because the per-test contexts are
+/// destroyed when a test ends.
+class SharedGLContextListener : public ::testing::EmptyTestEventListener
+{
+public:
+    void OnTestStart(const ::testing::TestInfo&) override
+    {
+        TestHelpers::OpenGLWindow::makeSharedCurrent();
+    }
+};
+
+} // anonymous namespace
 
 int main(int argc, char** argv)
 {
@@ -30,6 +47,18 @@ int main(int argc, char** argv)
     {
         std::cerr << "SDL initialization failed: " << SDL_GetError() << std::endl;
         return EXIT_FAILURE;
+    }
+
+    // Keep a shared OpenGL context current for the whole process so that OpenUSD's Storm
+    // support probe (which reads HgiGL capabilities) succeeds even during Vulkan-only tests.
+    if (TestHelpers::OpenGLWindow::createShared())
+    {
+        ::testing::UnitTest::GetInstance()->listeners().Append(new SharedGLContextListener);
+    }
+    else
+    {
+        std::cerr << "No shared OpenGL context: the Vulkan tests are expected to fail."
+                  << std::endl;
     }
 
     int ret = EXIT_FAILURE;
@@ -50,6 +79,7 @@ int main(int argc, char** argv)
     // and static destructors would only run after main() returns.
     TestHelpers::releaseSharedHgi();
 
+    TestHelpers::OpenGLWindow::destroyShared();
     SDL_Quit();
 
     return ret;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
+
 #include <RenderingFramework/OpenGLTestContext.h>
 #include <RenderingFramework/TestHelpers.h>
 #include <RenderingFramework/UsdHelpers.h>


### PR DESCRIPTION
OpenUSD answers "is Storm supported" by building the platform default Hgi (HgiGL on Windows) and reading its capabilities, and it runs that probe without the caller's Hgi. With no OpenGL context current the probe reports an API version of 0, so Storm is declared unsupported even though the test renders with Vulkan, and CreateRenderDelegate() returns null. The first such probe also latches an empty OpenGL entry point table process-wide (GarchGLApiLoad() runs only once), which is why every OpenGL test after the first Vulkan test would fail as well.

Add a SharedGLContext utility to the RenderingFramework that creates a hidden SDL window with an OpenGL context and keeps it current via a gtest event listener that restores it before each test, because the per-test contexts are destroyed when a test ends.

TestHelpers.cpp previously documented this gap as "a separate, larger change" (OpenGL was excluded from the shared-Hgi cache because HgiGL's cached GPU objects live inside the GL context).

## Description

<!-- Provide a clear and concise description of what this PR does -->

### Changes Made

<!-- List the key changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration
- **Platform(s) tested**: <!-- e.g., Windows 11, Ubuntu 22.04, macOS 14.2 -->
- **Build configuration(s)**: <!-- e.g., Debug, Release, RelWithDebInfo -->
- **Render delegate(s)**: <!-- e.g., Storm (OpenGL), Storm (Metal) -->
- **OpenUSD version**: <!-- e.g., v24.08 -->

### Tests Performed
<!-- Check all that apply -->
- [ ] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

## Documentation

<!-- Check all that apply -->

- [ ] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments

## Checklist

<!-- Complete all items before requesting review -->

- [ ] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [ ] My code follows the project's coding standards
- [ ] My changes generate no new warnings or errors
