### PR TITLE
Serialize GPU VM access and avoid stranding queued runs

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -24,6 +24,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: gpu-vm
+  cancel-in-progress: false
+
 jobs:
   start-vm:
     name: Start GPU VM
@@ -63,6 +67,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
     steps:
       - name: Azure Login
         uses: azure/login@v2
@@ -72,5 +77,16 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deallocate VM
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          PENDING=$(gh run list \
+            --workflow ci-test.yaml \
+            --json status,databaseId \
+            --jq '[.[] | select(.status=="queued" or .status=="in_progress") | select(.databaseId != "${{ github.run_id }}")] | length')
+          echo "Other GPU runs still active/queued: $PENDING"
+          if [ "$PENDING" != "0" ]; then
+            echo "Another run is waiting for the GPU VM; leaving it powered on."
+            exit 0
+          fi
           az vm deallocate --resource-group agp-rg-image-service --name AGP-U24T4-GPU-VM


### PR DESCRIPTION
## Problem

The GPU VM (`AGP-U24T4-GPU-VM`) is a single self-hosted runner (concurrency 1), but the CI workflow had no serialization around it. Two issues resulted:

1. **Runs race over the VM.** With no `concurrency` group, a push to `main` and a PR run can both call `az vm start` / `az vm deallocate` on the same VM at the same time, interleaving start/stop against an in-progress `tests` job.

2. **Queued runs get stranded.** `stop-vm` runs `if: always()`, so every run deallocates the VM when it finishes — even when another run is queued behind it. Since the runner agent lives on that VM, deallocation takes the runner offline, and the queued `tests` job finds no online `self-hosted` runner and never gets scheduled.

Evidence from [run 33230610650](https://github.com/Autodesk/hydra-viewport-toolbox/actions/runs/33230610650): `Start GPU VM` succeeds (runs on `ubuntu-latest`), but `tests / build` stays `queued` indefinitely because the VM was deallocated by the prior run's `stop-vm`.

## Fix

- Add a workflow-level `concurrency` group (`gpu-vm`, `cancel-in-progress: false`) so triggers queue strictly behind the running one instead of racing.
- In `stop-vm`, query for other `queued`/`in_progress` runs of this workflow (excluding self) and skip `az vm deallocate` when any exist, so the runner stays online for the next run.

This does not fully solve single-VM capacity (only one job runs at a time by design), but it prevents the stranding where a queued run never recovers.
