### PR TITLE
[NOM-5453] Fix hvt_embed_sublibraries() for static builds

### DIFF
--- a/cmake/HvtHelpers.cmake
+++ b/cmake/HvtHelpers.cmake
@@ -16,8 +16,8 @@ endfunction()
 #   )
 #
 # NOTE: Sub-libraries are built as OBJECT libraries so the parent library can bake their
-# object files in directly (for shared builds). For the Emscripten generator, STATIC libraries
-# must be used instead because it needs real archive targets.
+# object files in directly, for both shared and static builds. For the Emscripten generator,
+# STATIC libraries must be used instead because it needs real archive targets.
 function(hvt_add_sublibrary TARGET)
     cmake_parse_arguments(ARG "" "" "SOURCES;HEADERS" ${ARGN})
 
@@ -58,10 +58,11 @@ function(hvt_embed_sublibraries TARGET)
         # Add the private sub-libraries to the target.
         target_link_libraries(${TARGET} PRIVATE ${ARGN})
     else()
-        # Bake the private sub-libraries' object files directly into the parent target.
-        # BUILD_INTERFACE keeps TARGET_OBJECTS out of the installed export (consumers link libhvt only).
+        # Objects must be SOURCES, not link items: a static archive has no link line, so
+        # $<TARGET_OBJECTS> given to target_link_libraries() never reaches it. Keep it PRIVATE:
+        # PUBLIC/INTERFACE would leak $<TARGET_OBJECTS> into the installed export.
         foreach(_lib ${ARGN})
-            target_link_libraries(${TARGET} PRIVATE "$<BUILD_INTERFACE:$<TARGET_OBJECTS:${_lib}>>")
+            target_sources(${TARGET} PRIVATE "$<TARGET_OBJECTS:${_lib}>")
         endforeach()
     endif()
 endfunction()


### PR DESCRIPTION
## Description

`hvt_embed_sublibraries()` is meant to bake the sub-library object files into the
parent library, but it passed them to `target_link_libraries()`. A static archive
has no link line - it is assembled from its target's SOURCES - so with
`BUILD_SHARED_LIBS=OFF` nothing was embedded, and `$<BUILD_INTERFACE:...>` dropped
the same entries from the installed export. A static install therefore shipped a
~2 KB `libhvt` plus bare `$<LINK_ONLY:>` stubs in `hvtTargets.cmake`, and
consumers failed to link with all of hvt undefined. Shared builds were unaffected.

`target_sources()` puts the objects where a static archive reads them from. It
stays `PRIVATE`, so `$<TARGET_OBJECTS>` is still kept out of the installed export
and consumers link `libhvt` only, which was the original intent of the helper.

### Changes Made

- `hvt_embed_sublibraries()`: embed via `target_sources(<target> PRIVATE
  $<TARGET_OBJECTS:...>)` instead of `target_link_libraries()`.

## Testing

### Test Configuration
- **Platform(s) tested**: Windows 11 (MSVC 14.44, Ninja)
- **Build configuration(s)**: Release, both `BUILD_SHARED_LIBS=OFF` and `ON`
- **Render delegate(s)**: n/a - build-system change only
- **OpenUSD version**: 26.05

### Tests Performed
- [ ] Existing unit tests pass
- [ ] Added/Updated unit test(s) for the changes
- [ ] Tested on multiple platforms
- [ ] Tested with different render delegates
- [ ] Performance testing (if applicable)

Static install before/after: `libhvt` 2,326 bytes -> ~182 MB, no bare
`$<LINK_ONLY:>` left in the exported targets, and a downstream static consumer
links and runs. Shared builds verified unaffected on a standalone CMake project
(CMake 4.4.2 + MSVC): with `__declspec` exports, a consumer calling a
sub-library symbol through a shared parent links with both the old and the new
form.

Not verified locally: non-Windows platforms.

## Documentation

- [x] Code is self-documenting / well-commented
- [ ] Public API changes are documented with Doxygen comments