### PR TITLE
Fix workflow_dispatch crash in CI Tests workflow

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -50,7 +50,7 @@ jobs:
       runner: gpu
       build_type: ${{ github.event.inputs.build_type || 'debug' }}
       enable_tests: true
-      enable_coverage: ${{ github.event.inputs.enable_coverage || github.event_name != 'workflow_dispatch' }}
+      enable_coverage: ${{ github.event.inputs.enable_coverage == 'true' || github.event_name != 'workflow_dispatch' }}
 
     secrets:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}


### PR DESCRIPTION
- The `enable_coverage` input expression used `||` on `github.event.inputs.enable_coverage`, but for `workflow_dispatch` that input is the string `'false'` (truthy), so the expression returned the string `'false'` instead of a boolean
- GitHub rejected it with `Unexpected value 'false'` and the `tests` job was never created — every manual dispatch of CI Tests failed this way (runs from Jan/Mar 2026 all show it)
- Compare against the string `'true'` explicitly so the expression yields a proper boolean for every event type (PR/push still enable coverage, manual dispatch respects the checkbox)