### PR TITLE
Clarify clang-format scope in agent skills: changed lines only

### DIFF
--- a/.claude/skills/commit-content/SKILL.md
+++ b/.claude/skills/commit-content/SKILL.md
@@ -36,7 +36,8 @@ line-by-line of the diff.>
 
 ## Before you commit
 
-1. Run `clang-format` on changed C++ files (see the `openusd-coding-style` skill).
+1. Run `clang-format` on the **changed lines** of changed C++ files — not whole files, which would
+   sweep in pre-existing formatting drift (see the `openusd-coding-style` skill → Formatting scope).
 2. Every **new** file has the Apache-2.0 license header with the current year.
 3. Include tests for behavior changes; add/update **one** How-to if a user-facing feature changed.
 4. Don't commit generated files (`include/hvt/namespace.h`), build output, or anything under

--- a/.claude/skills/openusd-coding-style/SKILL.md
+++ b/.claude/skills/openusd-coding-style/SKILL.md
@@ -36,8 +36,8 @@ Apache-2.0 header, using the **current calendar year**. Copy from `source/tasks/
 
 ## Formatting
 
-`.clang-format` is authoritative (`.editorconfig` mirrors it for non-C++ files). Run
-`clang-format` on changed files **before committing**. Key rules that flow from it:
+`.clang-format` is authoritative (`.editorconfig` mirrors it for non-C++ files). Key rules that flow
+from it:
 
 - Microsoft base style, C++17, **column limit 100**.
 - **East const** (`SdfPath const& uid`, `HgiTextureHandle const&`).
@@ -46,6 +46,18 @@ Apache-2.0 header, using the **current calendar year**. Copy from `source/tasks/
 - Braced init has a space (`float blur { 8.0f };`).
 - Do **not** disable `SortIncludes`. If a specific include order is required to compile, separate
   include blocks with a blank line and a short comment.
+
+**Formatting scope — changed lines only, never whole files.** Many files in the tree carry
+pre-existing formatting drift (pragma indentation, over-long lines, trailing whitespace) that
+`clang-format -i <file>` would rewrite. Reformatting untouched lines pollutes the diff, buries the
+semantic change, and creates review noise and merge conflicts. Before committing:
+
+1. Format only the lines you touched, e.g.
+   `clang-format -i --lines=<start>:<end> <file>` per edited hunk (or stage the change and use
+   `git clang-format`/`clang-format-diff.py` on the staged diff).
+2. Verify the result is format-clean for those ranges — e.g.
+   `clang-format --lines=<start>:<end> <file> | diff - <file>` shows no difference.
+3. Never run bare `clang-format -i <file>` on a file you did not (re)write entirely.
 
 ## Namespaces & tokens
 


### PR DESCRIPTION
## Overview

The pull request improves the coding style skill.

## Description

The openusd-coding-style skill said to run clang-format on changed files before committing, which reads as "format the entire changed file" which could greatly increase a file change size and burn the semantic change.

Make the line-scoped expectation explicit in both skills. The style skill gains a "Formatting scope" section with the --lines= and git-clang-format recipes and a verification command, and the commit-content pre-commit checklist now says changed lines, not whole files.

## Documentation

- [x] Code is self-documenting / well-commented
- [x] Public API changes are documented with Doxygen comments

## Checklist

- [x] **I have signed the Contributor License Agreement (CLA)** ([Corporate](../CLA/ADSKFormCorpContribAgmtforOpenSource.docx) or [Individual](../CLA/ADSKFormIndContribAgmtforOpenSource.docx))
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings or errors
