### PR TITLE
Bump macOS CI runner to macos-15 + update GitHub Actions to Node 24

### DIFF
--- a/.github/actions/coverage-report/action.yaml
+++ b/.github/actions/coverage-report/action.yaml
@@ -31,7 +31,7 @@ runs:
     - name: Generate Coverage PR Comment
       # Add sticky coverage comment to PRs
       if: github.event_name == 'pull_request'
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: coverage
         recreate: true
@@ -77,10 +77,10 @@ runs:
 
     - name: Upload Coverage Artifact to GitHub Pages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: pages
 
     - name: Deploy Coverage Artifact to GitHub Pages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5

--- a/.github/workflows/black-duck-security.yml
+++ b/.github/workflows/black-duck-security.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: recursive

--- a/.github/workflows/ci-steps.yaml
+++ b/.github/workflows/ci-steps.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         lfs: true
         submodules: recursive
@@ -52,7 +52,7 @@ jobs:
 
     - name: Setup compiler environment (Windows only)
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@v1.13.0
 
     - name: Setup vcpkg cache
       uses: ./.github/actions/setup-vcpkg-cache
@@ -103,14 +103,14 @@ jobs:
 
     - name: Upload test failure outputs
       if: failure() && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: test-outputs
         path: build/${{ inputs.build_type }}/computed
 
     - name: Upload vcpkg failure logs
       if: failure() && (steps.configure.outcome == 'failure' || steps.build.outcome == 'failure')
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: vcpkg-build-logs
         path: externals/vcpkg/buildtrees

--- a/.github/workflows/ci-steps.yaml
+++ b/.github/workflows/ci-steps.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ inputs.runner == 'linux' && 'ubuntu-24.04' || inputs.runner == 'windows' && 'windows-2022' || inputs.runner == 'mac' && 'macos-14' || inputs.runner == 'gpu' && 'self-hosted' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.runner == 'linux' && 'ubuntu-24.04' || inputs.runner == 'windows' && 'windows-2022' || inputs.runner == 'mac' && 'macos-15' || inputs.runner == 'gpu' && 'self-hosted' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -65,7 +65,7 @@ jobs:
       contents: read
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
- **macOS runner: macos-14 → macos-15** — macos-14 (Xcode 15.4) fails to build USD 26.8: its libc++ only routes `allocate_shared` through the allocator's `construct()` in C++20+, so USD's `HdRetainedTypedSampledDataSource` protected constructor is inaccessible when building as C++17 (`backPlateSchema.cpp` et al.). macos-15 (Xcode 16.4) removed that version guard and compiles clean — verified with a minimal repro of the exact pattern on both runner images. macos-14 is also deprecated by GitHub on Nov 2, 2026.
- **Actions bumped to Node 24 runtimes** — clears the `Node.js 20 is deprecated` warnings:
  - actions/checkout v4 → v5
  - actions/upload-artifact v4 → v5
  - azure/login v2 → v3
  - marocchino/sticky-pull-request-comment v2 → v3
  - actions/upload-pages-artifact v3 → v5
  - actions/deploy-pages v4 → v5
  - ilammy/msvc-dev-cmd v1 → v1.13.0 (still node20 upstream — warning remains for this one until they migrate; runner forces node24 so it works)

Fixes the macOS failures in CI Full since the USD 26.8 upgrade (Aug 31).